### PR TITLE
feat: add CI/CD workflow, git hooks, and linter configuration

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+# Pull Request
+
+## Summary
+
+-
+
+## Issue Linkage
+
+- Fixes # (default; use when no acceptance criteria exist)
+- Ref # (use when acceptance criteria exist)
+- Work is not complete until the issue is closed.
+- If no issue exists, open one before any work begins.
+
+## Testing
+
+- markdownlint
+- `go vet ./...`
+- `go test -race -count=1 ./...`
+
+## Notes
+
+-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,157 @@
+name: CI - Test and Validate
+
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+      - 'release/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docs-only:
+    name: docs-only
+    runs-on: ubuntu-latest
+    outputs:
+      docs-only: ${{ steps.detect.outputs.docs-only }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Detect docs-only changes
+        id: detect
+        uses: wphillipmoore/standard-actions/actions/docs-only-detect@develop
+
+  standards-compliance:
+    name: standards-compliance
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate standards
+        uses: wphillipmoore/standard-actions/actions/standards-compliance@develop
+        with:
+          commit-cutoff-sha: "11d94c9"
+
+  dependency-audit:
+    name: dependency-audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck (fail on any vulnerability)
+        run: govulncheck ./...
+
+  release-gates:
+    name: release-gates
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip on non-PR events
+        if: github.event_name != 'pull_request'
+        run: echo "Not a pull request; skipping release gates."
+
+      - name: Checkout code
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        if: github.event_name == 'pull_request'
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
+      - name: Version divergence gate (PRs targeting develop)
+        if: github.event_name == 'pull_request' && github.base_ref == 'develop'
+        run: |
+          git fetch origin main --depth=1
+          main_version=$(git show origin/main:go.mod | grep '^go ' | awk '{print $2}')
+          head_version=$(grep '^go ' go.mod | awk '{print $2}')
+          if [ "$main_version" = "$head_version" ]; then
+            echo "FAIL: go.mod version ($head_version) must differ from main ($main_version)."
+            exit 1
+          fi
+          echo "OK: go.mod version ($head_version) differs from main ($main_version)."
+
+      - name: Tag validation placeholder (PRs targeting main)
+        if: github.event_name == 'pull_request' && github.base_ref == 'main'
+        run: echo "Tag-based release validation not yet implemented for Go modules."
+
+  test-and-validate:
+    name: test-and-validate
+    runs-on: ubuntu-latest
+    needs: docs-only
+    strategy:
+      matrix:
+        go-version: ["1.25", "1.26"]
+
+    steps:
+      - name: Docs-only short-circuit
+        if: needs.docs-only.outputs.docs-only == 'true'
+        run: echo "Docs-only changes detected; skipping test-and-validate."
+
+      - name: Checkout code
+        if: needs.docs-only.outputs.docs-only != 'true'
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        if: needs.docs-only.outputs.docs-only != 'true'
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Run go vet
+        if: needs.docs-only.outputs.docs-only != 'true'
+        run: go vet ./...
+
+      - name: Run golangci-lint
+        if: needs.docs-only.outputs.docs-only != 'true'
+        uses: golangci/golangci-lint-action@v7
+
+      - name: Run tests with coverage
+        if: needs.docs-only.outputs.docs-only != 'true'
+        run: go test -race -count=1 -coverprofile=coverage.out ./...
+
+  integration-test:
+    name: integration-test
+    runs-on: ubuntu-latest
+    needs: docs-only
+    if: needs.docs-only.outputs.docs-only != 'true'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
+      - name: Setup MQ environment
+        uses: wphillipmoore/mq-dev-environment/.github/actions/setup-mq@main
+        with:
+          project-name: mq-rest-admin-go
+
+      - name: Run integration tests
+        run: |
+          MQ_SKIP_LIFECYCLE=1 \
+          MQ_REST_ADMIN_GO_RUN_INTEGRATION=1 \
+          go test -race -count=1 -tags=integration ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,24 @@
+linters:
+  enable:
+    - errcheck
+    - govet
+    - staticcheck
+    - unused
+    - gosimple
+    - ineffassign
+    - typecheck
+    - gocritic
+    - revive
+
+linters-settings:
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - style
+      - performance
+  revive:
+    rules:
+      - name: blank-imports
+      - name: exported
+      - name: unreachable-code
+      - name: unused-parameter

--- a/scripts/git-hooks/commit-msg
+++ b/scripts/git-hooks/commit-msg
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+
+"$repo_root/scripts/lint/commit-message.sh" "$1"
+"$repo_root/scripts/lint/co-author.sh" "$1"

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
+
+# Block detached HEAD unconditionally.
+if [[ "$current_branch" == "HEAD" ]]; then
+  echo "ERROR: detached HEAD is not allowed for commits." >&2
+  echo "Create a short-lived branch and open a PR." >&2
+  exit 1
+fi
+
+# Block commits to protected branches (universal set — safe for all models).
+case "$current_branch" in
+  develop|release|main|release/*)
+    echo "ERROR: direct commits to protected branches are forbidden ($current_branch)." >&2
+    echo "Create a short-lived branch and open a PR." >&2
+    exit 1
+    ;;
+esac
+
+# Read branching_model from the repository profile.
+repo_root="$(git rev-parse --show-toplevel)"
+profile_file="$repo_root/docs/repository-standards.md"
+branching_model=""
+
+if [[ -f "$profile_file" ]]; then
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^[[:space:]-]*branching_model:[[:space:]]*(.+)$ ]]; then
+      branching_model="${BASH_REMATCH[1]}"
+      break
+    fi
+  done < "$profile_file"
+fi
+
+# Set allowed branch prefixes based on branching model.
+case "$branching_model" in
+  docs-single-branch)
+    allowed_regex='^(feature|bugfix)/'
+    allowed_display="feature/* or bugfix/*"
+    ;;
+  application-promotion)
+    allowed_regex='^(feature|bugfix|hotfix|promotion)/'
+    allowed_display="feature/*, bugfix/*, hotfix/*, or promotion/*"
+    ;;
+  library-release)
+    allowed_regex='^(feature|bugfix|hotfix)/'
+    allowed_display="feature/*, bugfix/*, or hotfix/*"
+    ;;
+  "")
+    echo "WARNING: branching_model not found in $profile_file; falling back to feature/*/bugfix/*." >&2
+    allowed_regex='^(feature|bugfix)/'
+    allowed_display="feature/* or bugfix/*"
+    ;;
+  *)
+    echo "ERROR: unrecognized branching_model '$branching_model' in $profile_file." >&2
+    exit 1
+    ;;
+esac
+
+if [[ ! "$current_branch" =~ $allowed_regex ]]; then
+  echo "ERROR: branch name must use $allowed_display ($current_branch)." >&2
+  echo "Rename the branch before committing." >&2
+  exit 1
+fi

--- a/scripts/lint/co-author.sh
+++ b/scripts/lint/co-author.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+commit_message_file="${1:-}"
+
+if [[ -z "$commit_message_file" || ! -f "$commit_message_file" ]]; then
+  echo "ERROR: commit message file path is required." >&2
+  exit 2
+fi
+
+# Extract Co-Authored-By trailers from the commit message (case-insensitive match).
+trailers=()
+while IFS= read -r line; do
+  trailers+=("$line")
+done < <(grep -i '^Co-Authored-By:' "$commit_message_file" || true)
+
+# Human-only commits (no trailers) are valid.
+if [[ ${#trailers[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+# Read approved identities from the repository profile.
+repo_root="$(git rev-parse --show-toplevel)"
+profile_file="$repo_root/docs/repository-standards.md"
+
+if [[ ! -f "$profile_file" ]]; then
+  echo "ERROR: repository profile not found at $profile_file; cannot validate co-author trailers." >&2
+  exit 1
+fi
+
+approved=()
+while IFS= read -r line; do
+  approved+=("$line")
+done < <(grep -i '^\- Co-Authored-By:' "$profile_file" | sed 's/^- //' || true)
+
+if [[ ${#approved[@]} -eq 0 ]]; then
+  echo "ERROR: no approved co-author identities found in $profile_file." >&2
+  exit 1
+fi
+
+# Validate each trailer against the approved list.
+failed=0
+for trailer in "${trailers[@]}"; do
+  # Normalize whitespace for comparison.
+  normalized="$(echo "$trailer" | sed 's/[[:space:]][[:space:]]*/ /g; s/^ //; s/ $//')"
+  match=0
+  for identity in "${approved[@]}"; do
+    normalized_identity="$(echo "$identity" | sed 's/[[:space:]][[:space:]]*/ /g; s/^ //; s/ $//')"
+    if [[ "$normalized" == "$normalized_identity" ]]; then
+      match=1
+      break
+    fi
+  done
+  if [[ $match -eq 0 ]]; then
+    echo "ERROR: unapproved co-author trailer: $trailer" >&2
+    echo "Approved identities are listed in $profile_file under 'AI co-authors'." >&2
+    failed=1
+  fi
+done
+
+exit $failed

--- a/scripts/lint/commit-message.sh
+++ b/scripts/lint/commit-message.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+commit_message_file="${1:-}"
+
+if [[ -z "$commit_message_file" || ! -f "$commit_message_file" ]]; then
+  echo "ERROR: commit message file path is required." >&2
+  exit 2
+fi
+
+subject_line="$(head -n 1 "$commit_message_file")"
+
+conventional_regex='^(feat|fix|docs|style|refactor|test|chore)(\([^\)]+\))?: .+'
+
+if [[ ! "$subject_line" =~ $conventional_regex ]]; then
+  echo "ERROR: commit message does not follow Conventional Commits." >&2
+  echo "Expected: <type>(optional-scope): <description>" >&2
+  echo "Allowed types: feat, fix, docs, style, refactor, test, chore" >&2
+  echo "Got: $subject_line" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Add GitHub Actions CI workflow with 6 jobs matching the sibling Python/Java repo structure (docs-only, standards-compliance, dependency-audit, release-gates, test-and-validate with Go 1.25/1.26 matrix, integration-test)
- Add git hooks from standards-and-conventions (pre-commit branch protection, commit-msg conventional commits and co-author validation)
- Add golangci-lint configuration and PR template

## Test plan

- [ ] Verify all 6 CI jobs appear and run
- [ ] Confirm docs-only detection works (modify only .md files in a test commit)
- [ ] Confirm test matrix runs both Go versions (1.25, 1.26)
- [ ] Verify pre-commit hook blocks direct commits to develop/main
- [ ] Verify commit-msg hook enforces conventional commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)