### PR TITLE
Add workflow_dispatch trigger to docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -40,14 +41,14 @@ jobs:
         run: mkdocs build -f docs/site/mkdocs.yml --strict
 
       - name: Upload pages artifact
-        if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v3
         with:
           path: docs/site/site
 
   deploy:
     name: deploy
-    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+    if: github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` trigger to docs workflow for on-demand builds
- Update deploy conditions to allow manual triggers to publish (not just push events)

## Issue Linkage

Ref #13

## Testing

Docs-only: tests skipped

## Notes

Docs-only change — single workflow file modified.