### PR TITLE
docs: fix hallucinated API references and correct ensure method count

### DIFF
--- a/docs/site/docs/api/ensure.md
+++ b/docs/site/docs/api/ensure.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The ensure methods provide 15 idempotent ensure operations on `Session`. These
+The ensure methods provide 16 idempotent ensure operations on `Session`. These
 methods implement a declarative upsert pattern: DEFINE if the object does not
 exist, ALTER only attributes that differ, or no-op if the object already matches
 the desired state.

--- a/docs/site/docs/api/session.md
+++ b/docs/site/docs/api/session.md
@@ -5,7 +5,7 @@
 The main entry point for interacting with an IBM MQ queue manager's
 administrative REST API. A `Session` encapsulates connection details,
 authentication, attribute mapping configuration, and diagnostic state. It
-provides ~144 command methods covering all MQSC verbs and qualifiers, plus 15
+provides ~144 command methods covering all MQSC verbs and qualifiers, plus 16
 idempotent ensure methods and 9 synchronous sync methods.
 
 The Go implementation uses functional options for construction, following
@@ -114,7 +114,7 @@ err = session.DeleteQueue(ctx, "MY.QUEUE")
 
 ## Ensure methods
 
-The session provides 15 ensure methods for declarative object management. Each
+The session provides 16 ensure methods for declarative object management. Each
 method implements an idempotent upsert: DEFINE if the object does not exist,
 ALTER only the attributes that differ, or no-op if already correct.
 

--- a/docs/site/docs/architecture.md
+++ b/docs/site/docs/architecture.md
@@ -7,9 +7,9 @@ components are:
 
 - **`Session`**: The main entry point. A single struct that owns connection
   details, authentication, mapping configuration, diagnostic state, and all
-  ~144 command methods plus 15 ensure methods and 9 sync methods. Created
+  ~144 command methods plus 16 ensure methods and 9 sync methods. Created
   via `NewSession` with functional options.
-- **Command methods**: Exported methods on `Session` (e.g. `DisplayQlocal()`,
+- **Command methods**: Exported methods on `Session` (e.g. `DisplayQueue()`,
   `DefineQlocal()`, `DeleteChannel()`). Each method is a thin wrapper that
   calls the internal `mqscCommand()` dispatcher with the correct verb and
   qualifier.
@@ -21,7 +21,7 @@ components are:
 
 ## Request lifecycle
 
-When you call a command method like `session.DisplayQlocal(ctx, "*")`:
+When you call a command method like `session.DisplayQueue(ctx, "*")`:
 
 1. The method delegates to the internal `mqscCommand()` dispatcher with the
    verb (`DISPLAY`), qualifier (`QLOCAL`), and name.
@@ -35,7 +35,7 @@ When you call a command method like `session.DisplayQlocal(ctx, "*")`:
 6. The session retains diagnostic state from the most recent command.
 
 ```go
-session.DisplayQlocal(ctx, "MY.QUEUE")
+session.DisplayQueue(ctx, "MY.QUEUE")
 
 session.LastCommandPayload    // the JSON sent to MQ
 session.LastResponsePayload   // the parsed JSON response

--- a/docs/site/docs/design/rationale.md
+++ b/docs/site/docs/design/rationale.md
@@ -36,7 +36,7 @@ configuration struct or builder:
 session, err := mqrestadmin.NewSession(
     "https://localhost:9443/ibmmq/rest/v2",
     "QM1",
-    mqrestadmin.WithBasicAuth("mqadmin", "mqadmin"),
+    mqrestadmin.LTPAAuth{Username: "mqadmin", Password: "mqadmin"},
     mqrestadmin.WithVerifyTLS(false),
     mqrestadmin.WithTimeout(30 * time.Second),
 )
@@ -50,7 +50,7 @@ without nil checks, and backward-compatible extensibility.
 All I/O methods accept `context.Context` as their first parameter:
 
 ```go
-results, err := session.DisplayQlocal(ctx, "MY.QUEUE")
+results, err := session.DisplayQueue(ctx, "MY.QUEUE")
 ```
 
 This enables cancellation, deadline propagation, and tracing integration
@@ -62,11 +62,11 @@ Go errors follow the standard `error` interface with typed error structs
 for classification:
 
 ```go
-results, err := session.DisplayQlocal(ctx, "MY.QUEUE")
+results, err := session.DisplayQueue(ctx, "MY.QUEUE")
 if err != nil {
     var cmdErr *mqrestadmin.CommandError
     if errors.As(err, &cmdErr) {
-        fmt.Printf("reason code: %d\n", cmdErr.ReasonCode)
+        fmt.Printf("status: %d, payload: %v\n", cmdErr.StatusCode, cmdErr.Payload)
     }
     return err
 }

--- a/docs/site/docs/design/runcommand-endpoint.md
+++ b/docs/site/docs/design/runcommand-endpoint.md
@@ -27,6 +27,6 @@ typed error structs:
 - DISPLAY commands with no matches (reason code 2085) return an empty
   slice and nil error.
 - The CSRF token defaults to `"local"` and can be overridden via
-  `WithCSRFToken()`, or omitted with `WithCSRFToken("")`.
-- Authentication is configured via functional options: `WithBasicAuth()`,
-  `WithCertificateAuth()`, or `WithLTPAToken()`.
+  `WithCSRFToken(&token)`, or omitted with `WithCSRFToken(nil)`.
+- Authentication is configured via credential structs passed to `NewSession()`:
+  `BasicAuth{}`, `CertificateAuth{}`, or `LTPAAuth{}`.

--- a/docs/site/docs/development/local-mq-container.md
+++ b/docs/site/docs/development/local-mq-container.md
@@ -123,7 +123,7 @@ curl -k -u mqadmin:mqadmin \
 session, err := mqrestadmin.NewSession(
     "https://localhost:9443/ibmmq/rest/v2",
     "QM2",
-    mqrestadmin.WithBasicAuth("mqadmin", "mqadmin"),
+    mqrestadmin.LTPAAuth{Username: "mqadmin", Password: "mqadmin"},
     mqrestadmin.WithGatewayQmgr("QM1"),
     mqrestadmin.WithVerifyTLS(false),
 )

--- a/docs/site/docs/getting-started.md
+++ b/docs/site/docs/getting-started.md
@@ -50,7 +50,7 @@ follow the pattern `VerbQualifier` in PascalCase:
 ctx := context.Background()
 
 // DISPLAY QUEUE — returns a slice of maps
-queues, err := session.DisplayQlocal(ctx, "*")
+queues, err := session.DisplayQueue(ctx, "*")
 if err != nil {
     panic(err)
 }
@@ -73,7 +73,7 @@ err := session.DefineQlocal(ctx, "APP.REQUESTS", map[string]any{
 })
 
 // Response: MQSC → snake_case
-queues, _ := session.DisplayQlocal(ctx, "APP.REQUESTS")
+queues, _ := session.DisplayQueue(ctx, "APP.REQUESTS")
 fmt.Println(queues[0]["max_queue_depth"])      // "50000"
 fmt.Println(queues[0]["default_persistence"])  // "persistent"
 ```


### PR DESCRIPTION
## Summary

- Fix hallucinated `DisplayQlocal()` → `DisplayQueue()` in 7 places across 3 files
- Fix hallucinated `WithBasicAuth()` functional option → `LTPAAuth{}` struct literal in 3 files
- Fix hallucinated `CommandError.ReasonCode` → `StatusCode`/`Payload` fields
- Fix `WithCSRFToken("")` → `WithCSRFToken(nil)` for omitting CSRF header
- Fix incorrect "15 ensure methods" → "16 ensure methods" in 3 files

## Issue Linkage

- Fixes #18
- Ref mq-rest-admin-common#5

## Testing

- `mkdocs build -f docs/site/mkdocs.yml --strict` passes

Docs-only: tests skipped

## Notes

- All fixes verified against Go source code
- `LTPAAuth` (all-caps LTPA) confirmed as the correct type name