### PR TITLE
chore: restrict docs deploy to main branch and manual dispatch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,8 +3,7 @@ name: Docs - Build and Deploy
 on:
   push:
     branches:
-      - develop
-  pull_request:
+      - main
   workflow_dispatch:
 
 permissions:
@@ -41,14 +40,14 @@ jobs:
         run: mkdocs build -f docs/site/mkdocs.yml --strict
 
       - name: Upload pages artifact
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: actions/upload-pages-artifact@v3
         with:
           path: docs/site/site
 
   deploy:
     name: deploy
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     needs: build
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

- Change push trigger from `develop` to `main`
- Remove `pull_request` trigger
- Normalize deploy conditions to `push || workflow_dispatch` (matching Java/Python)
- Auto-deploy only on push to `main` (releases)
- Keep `workflow_dispatch` for manual deployments

Fixes #22