### PR TITLE
docs: address cross-library documentation consistency nits

### DIFF
--- a/docs/site/docs/examples.md
+++ b/docs/site/docs/examples.md
@@ -1,0 +1,173 @@
+# Examples
+
+The `examples/` directory contains practical scripts that demonstrate common
+MQ administration tasks using `mqrestadmin`. Each example is self-contained
+and can be run against the local Docker environment.
+
+## Prerequisites
+
+Start the multi-queue-manager Docker environment and seed both queue managers:
+
+```bash
+./scripts/dev/mq_start.sh
+./scripts/dev/mq_seed.sh
+```
+
+This starts two queue managers (`QM1` on port 9443, `QM2` on port 9444) on a
+shared Docker network. See [local MQ container](development/local-mq-container.md) for details.
+
+## Health check
+
+Connect to one or more queue managers and check:
+
+- Queue manager attributes via `DisplayQmgr()`
+- Running status via `DisplayQmstatus()`
+- Listener definitions via `DisplayListener()`
+
+```go
+ctx := context.Background()
+
+qmgr, err := session.DisplayQmgr(ctx)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println("Queue manager:", qmgr["queue_manager_name"])
+
+status, err := session.DisplayQmstatus(ctx)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println("Status:", status["channel_initiator_status"])
+
+listeners, err := session.DisplayListener(ctx, "*")
+if err != nil {
+    log.Fatal(err)
+}
+for _, listener := range listeners {
+    fmt.Printf("Listener: %s port=%v\n",
+        listener["listener_name"], listener["port"])
+}
+```
+
+## Queue depth monitor
+
+Display all local queues with their current depth and flag queues
+approaching capacity:
+
+```go
+ctx := context.Background()
+
+queues, err := session.DisplayQueue(ctx, "*")
+if err != nil {
+    log.Fatal(err)
+}
+
+for _, queue := range queues {
+    depth, _ := strconv.Atoi(fmt.Sprint(queue["current_queue_depth"]))
+    maxDepth, _ := strconv.Atoi(fmt.Sprint(queue["max_queue_depth"]))
+    pct := 0
+    if maxDepth > 0 {
+        pct = depth * 100 / maxDepth
+    }
+    flag := ""
+    if pct > 80 {
+        flag = " *** HIGH ***"
+    }
+    fmt.Printf("%-40s %5d / %5d (%d%%)%s\n",
+        queue["queue_name"], depth, maxDepth, pct, flag)
+}
+```
+
+## Channel status report
+
+Cross-reference channel definitions with live channel status:
+
+```go
+ctx := context.Background()
+
+channels, err := session.DisplayChannel(ctx, "*")
+if err != nil {
+    log.Fatal(err)
+}
+
+statuses, err := session.DisplayChstatus(ctx, "*")
+if err != nil {
+    log.Fatal(err)
+}
+
+running := make(map[string]bool)
+for _, s := range statuses {
+    running[fmt.Sprint(s["channel_name"])] = true
+}
+
+for _, ch := range channels {
+    name := fmt.Sprint(ch["channel_name"])
+    state := "INACTIVE"
+    if running[name] {
+        state = "RUNNING"
+    }
+    fmt.Println(name + ": " + state)
+}
+```
+
+## Environment provisioner
+
+Demonstrate bulk provisioning across two queue managers using ensure
+methods:
+
+```go
+ctx := context.Background()
+
+// Ensure application queues exist on QM1
+_, err := session.EnsureQlocal(ctx, "APP.REQUESTS", map[string]any{
+    "max_queue_depth":     "50000",
+    "default_persistence": "persistent",
+})
+if err != nil {
+    log.Fatal(err)
+}
+
+_, err = session.EnsureQlocal(ctx, "APP.RESPONSES", map[string]any{
+    "max_queue_depth":     "50000",
+    "default_persistence": "persistent",
+})
+if err != nil {
+    log.Fatal(err)
+}
+
+// Ensure listeners are running
+config := mqrestadmin.SyncConfig{Timeout: 60 * time.Second}
+_, err = session.StartListenerSync(ctx, "TCP.LISTENER", config)
+if err != nil {
+    log.Fatal(err)
+}
+
+fmt.Println("Environment provisioned")
+```
+
+## Dead letter queue inspector
+
+Inspect the dead letter queue configuration:
+
+```go
+ctx := context.Background()
+
+qmgr, err := session.DisplayQmgr(ctx)
+if err != nil {
+    log.Fatal(err)
+}
+
+dlqName, ok := qmgr["dead_letter_q_name"].(string)
+if ok && dlqName != "" {
+    dlq, err := session.DisplayQueue(ctx, dlqName)
+    if err != nil {
+        log.Fatal(err)
+    }
+    if len(dlq) > 0 {
+        fmt.Printf("DLQ: %s depth=%v max=%v\n",
+            dlqName, dlq[0]["current_queue_depth"], dlq[0]["max_queue_depth"])
+    }
+} else {
+    fmt.Println("No dead letter queue configured")
+}
+```

--- a/docs/site/docs/getting-started.md
+++ b/docs/site/docs/getting-started.md
@@ -60,31 +60,53 @@ for _, queue := range queues {
 }
 ```
 
-## Attribute mapping
-
-By default, attribute names are translated between `snake_case` and MQSC
-parameter names:
-
 ```go
-// Request: snake_case → MQSC
-err := session.DefineQlocal(ctx, "APP.REQUESTS", map[string]any{
-    "max_queue_depth":      "50000",
-    "default_persistence":  "persistent",
-})
-
-// Response: MQSC → snake_case
-queues, _ := session.DisplayQueue(ctx, "APP.REQUESTS")
-fmt.Println(queues[0]["max_queue_depth"])      // "50000"
-fmt.Println(queues[0]["default_persistence"])  // "persistent"
+// DISPLAY QMGR — returns a single map or nil
+qmgr, err := session.DisplayQmgr(ctx)
+if err != nil {
+    panic(err)
+}
+if qmgr != nil {
+    fmt.Println(qmgr["queue_manager_name"])
+}
 ```
 
-Disable mapping per-session with `WithMapAttributes(false)` to work with
-raw MQSC parameter names.
+## Attribute mapping
 
-### Strict and lenient modes
+By default, the session maps between developer-friendly `snake_case` names
+and MQSC parameter names. This applies to both request and response attributes:
 
-By default, the mapper runs in **lenient** mode — unrecognized attributes pass
-through unchanged. Switch to **strict** mode to get errors on unmapped keys:
+```go
+// With mapping enabled (default)
+queues, _ := session.DisplayQueue(ctx, "MY.QUEUE",
+    map[string]any{"response_parameters": []string{"current_queue_depth", "max_queue_depth"}},
+)
+// Returns: [{"queue_name": "MY.QUEUE", "current_queue_depth": 0, "max_queue_depth": 5000}]
+
+// With mapping disabled
+queues, _ = session.DisplayQueue(ctx, "MY.QUEUE",
+    map[string]any{"response_parameters": []string{"CURDEPTH", "MAXDEPTH"}},
+)
+// Returns: [{"queue": "MY.QUEUE", "curdepth": 0, "maxdepth": 5000}]
+```
+
+Mapping can be disabled at the session level:
+
+```go
+session, err := mqrestadmin.NewSession(
+    "https://localhost:9443/ibmmq/rest/v2", "QM1",
+    mqrestadmin.LTPAAuth{Username: "mqadmin", Password: "mqadmin"},
+    mqrestadmin.WithMapAttributes(false),
+)
+```
+
+See [mapping pipeline](mapping-pipeline.md) for a detailed explanation of how
+mapping works.
+
+## Strict vs lenient mapping
+
+By default, mapping runs in lenient mode. Unknown attribute names or values
+pass through unchanged. In strict mode, unknown attributes return an error:
 
 ```go
 session, err := mqrestadmin.NewSession(
@@ -94,80 +116,110 @@ session, err := mqrestadmin.NewSession(
 )
 ```
 
-### Custom mapping overrides
+## Custom mapping overrides
 
-Override or extend the built-in mapping data:
+Sites with existing naming conventions can override individual entries in the
+built-in mapping tables without replacing them entirely. Pass override data
+when creating the session:
 
 ```go
+overrideData := map[string]any{
+    "qualifiers": map[string]any{
+        "queue": map[string]any{
+            "response_key_map": map[string]any{
+                "CURDEPTH": "queue_depth",      // override built-in mapping
+                "MAXDEPTH": "queue_max_depth",   // override built-in mapping
+            },
+        },
+    },
+}
+
 session, err := mqrestadmin.NewSession(
     "https://localhost:9443/ibmmq/rest/v2", "QM1",
     mqrestadmin.LTPAAuth{Username: "mqadmin", Password: "mqadmin"},
     mqrestadmin.WithMappingOverride(overrideData, mqrestadmin.MergeOverride),
 )
+
+queues, _ := session.DisplayQueue(ctx, "MY.QUEUE")
+// Returns: [{"queue_depth": 0, "queue_max_depth": 5000, ...}]
 ```
 
-See [mapping pipeline](mapping-pipeline.md) for a detailed explanation of
-how mapping works.
+Overrides are **sparse** — you only specify the entries you want to change. All
+other mappings in the qualifier continue to work as normal. In the example above,
+only `CURDEPTH` and `MAXDEPTH` are remapped; every other queue attribute keeps
+its default `snake_case` name.
 
-## Idempotent operations
+Overrides support all five sub-maps per qualifier: `request_key_map`,
+`request_value_map`, `request_key_value_map`, `response_key_map`, and
+`response_value_map`. See [mapping pipeline](mapping-pipeline.md) for details
+on how each sub-map is used.
 
-Ensure methods implement a declarative upsert pattern — define if the object
-does not exist, alter only the attributes that differ, or no-op if everything
-matches:
+## Gateway queue manager
+
+The MQ REST API is available on all supported IBM MQ platforms (Linux, AIX,
+Windows, z/OS, and IBM i). mqrestadmin is developed and tested against the
+**Linux** implementation only.
+
+In enterprise environments, a **gateway queue manager** can route MQSC
+commands to remote queue managers via MQ channels — the same mechanism used
+by `runmqsc -w` and the MQ Console.
+
+To use a gateway, pass `WithGatewayQmgr` when creating the session. The
+base URL and queue manager name specify the **target** (remote) queue manager,
+while `WithGatewayQmgr` names the **local** queue manager whose REST API
+routes the command:
 
 ```go
-result, err := session.EnsureQlocal(ctx, "APP.REQUESTS", map[string]any{
-    "max_queue_depth": "50000",
-})
-if err != nil {
-    panic(err)
-}
-fmt.Println(result.Action) // created, updated, or unchanged
-```
-
-See [ensure methods](ensure-methods.md) for details.
-
-## Gateway routing
-
-Route commands to a remote queue manager through a local gateway:
-
-```go
+// Route commands to QM2 through QM1's REST API
 session, err := mqrestadmin.NewSession(
-    "https://localhost:9443/ibmmq/rest/v2",
-    "QM2",                                     // target (remote) queue manager
+    "https://qm1-host:9443/ibmmq/rest/v2",
+    "QM2",                                     // target queue manager
     mqrestadmin.LTPAAuth{Username: "mqadmin", Password: "mqadmin"},
     mqrestadmin.WithGatewayQmgr("QM1"),        // local gateway queue manager
     mqrestadmin.WithVerifyTLS(false),
 )
+
+qmgr, _ := session.DisplayQmgr(ctx)
+// Returns QM2's queue manager attributes, routed through QM1
+```
+
+Prerequisites:
+
+- The gateway queue manager must have a running REST API.
+- MQ channels must be configured between the gateway and target queue managers.
+- A QM alias (QREMOTE with empty RNAME) must map the target QM name to the
+  correct transmission queue on the gateway.
+
+## Error handling
+
+`DISPLAY` commands return an empty slice when no objects match. Queue manager
+display methods return `nil` when no match is found. Non-display commands
+return a `*CommandError` on failure:
+
+```go
+// Empty slice — no error
+result, err := session.DisplayQueue(ctx, "NONEXISTENT.*")
+// result == []
+
+// Define returns error on failure
+var cmdErr *mqrestadmin.CommandError
+err = session.DefineQlocal(ctx, "MY.QUEUE", nil)
+if errors.As(err, &cmdErr) {
+    fmt.Println(cmdErr.Error())
+    fmt.Println("HTTP status:", cmdErr.StatusCode)
+    fmt.Println(cmdErr.Payload) // full MQ response payload
+}
 ```
 
 ## Diagnostic state
 
-After every command, the session retains diagnostic state for debugging:
+The session retains the most recent request and response for inspection:
 
 ```go
-queues, err := session.DisplayQueue(ctx, "MY.QUEUE")
+session.DisplayQueue(ctx, "MY.QUEUE")
 
+fmt.Println(session.LastCommandPayload)    // the JSON sent to MQ
+fmt.Println(session.LastResponsePayload)   // the parsed JSON response
 fmt.Println(session.LastHTTPStatus)        // HTTP status code
-fmt.Println(session.LastCommandPayload)    // JSON sent to MQ
-fmt.Println(session.LastResponsePayload)   // parsed JSON response
 fmt.Println(session.LastResponseText)      // raw response body
 ```
-
-## Error handling
-
-All error types are designed for use with `errors.As()`:
-
-```go
-var cmdErr *mqrestadmin.CommandError
-if errors.As(err, &cmdErr) {
-    fmt.Println("MQSC command failed:", cmdErr.Payload)
-}
-```
-
-## What's next
-
-- [Architecture](architecture.md) — how the components fit together
-- [Mapping Pipeline](mapping-pipeline.md) — how attribute translation works
-- [Ensure Methods](ensure-methods.md) — idempotent object management
-- [Sync Methods](sync-methods.md) — synchronous polling operations

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -1,10 +1,33 @@
 # mqrestadmin
 
-Go wrapper for the IBM MQ administrative REST API.
+## Overview
 
-`mqrestadmin` provides typed Go methods for every MQSC command exposed
-by the IBM MQ 9.4 `runCommandJSON` REST endpoint. Attribute names are
-automatically translated between Go `snake_case` and native MQSC
-parameter names, so you work with idiomatic Go identifiers throughout.
+**mqrestadmin** provides a Go-friendly interface to IBM MQ queue manager
+administration via the `runCommandJSON` REST endpoint. It translates between
+Go `snake_case` attribute names and native MQSC parameter names, wraps
+every MQSC command as a typed method, and handles authentication, CSRF tokens,
+and error propagation.
 
-Zero external runtime dependencies — stdlib only.
+## Key features
+
+- **~144 command methods** covering all MQSC verbs and qualifiers
+- **Bidirectional attribute mapping** between developer-friendly names and MQSC parameters
+- **Idempotent ensure methods** for declarative object management
+- **Bulk sync operations** for configuration-as-code workflows
+- **Zero runtime dependencies** — stdlib only
+- **Transport abstraction** for easy testing with mock transports
+
+## Installation
+
+```bash
+go get github.com/wphillipmoore/mq-rest-admin-go/mqrestadmin
+```
+
+## Status
+
+This project is in **pre-alpha** (initial setup). The API surface, mapping
+tables, and return shapes are under active development.
+
+## License
+
+GNU General Public License v3.0

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -60,15 +60,16 @@ nav:
   - Mapping Pipeline: mapping-pipeline.md
   - Ensure Methods: ensure-methods.md
   - Sync Methods: sync-methods.md
+  - Examples: examples.md
   - API Reference:
       - api/index.md
       - Session: api/session.md
       - Authentication: api/auth.md
       - Commands: api/commands.md
+      - Transport: api/transport.md
+      - Mapping: api/mapping.md
       - Ensure: api/ensure.md
       - Sync: api/sync.md
-      - Mapping: api/mapping.md
-      - Transport: api/transport.md
       - Errors: api/errors.md
   - Mappings:
       - mappings/index.md
@@ -118,9 +119,9 @@ nav:
       - Rationale: design/rationale.md
       - runCommandJSON Endpoint: design/runcommand-endpoint.md
       - Nested Object Flattening: design/nested-object-flattening.md
-  - AI Engineering: ai-engineering.md
   - Development:
       - development/index.md
       - Developer Setup: development/developer-setup.md
       - Contributing: development/contributing.md
       - Local MQ Container: development/local-mq-container.md
+  - AI Engineering: ai-engineering.md


### PR DESCRIPTION
## Summary

- Enrich home page from stub to full page matching Python/Java structure
- Rewrite getting-started.md to match Python/Java depth (strict/lenient, custom overrides, gateway, error handling)
- Create examples.md with health check, queue depth monitor, channel status, environment provisioner, and DLQ inspector examples
- Standardize nav ordering to match Python/Java

## Test plan

- [x] `mkdocs build --strict` passes
- Docs-only: tests skipped

Fixes #24
Ref wphillipmoore/mq-rest-admin-common#18

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>