### PR TITLE
docs: add quality gates documentation page

### DIFF
--- a/docs/site/docs/development/quality-gates.md
+++ b/docs/site/docs/development/quality-gates.md
@@ -1,0 +1,25 @@
+# Quality gates
+
+--8<-- "development/quality-gates.md"
+
+## Go-specific validation
+
+The Go validation pipeline runs as individual commands:
+
+```bash
+go vet ./...
+golangci-lint run
+go test -race -count=1 -coverprofile=coverage.out ./...
+```
+
+This covers:
+
+1. **go vet** — Standard Go static analysis
+2. **golangci-lint** — Comprehensive linter suite
+3. **go test -race** — Unit tests with race detector enabled
+4. **Coverage enforcement** — 100% coverage after `go-ignore-cov` exclusions
+5. **govulncheck** — Dependency vulnerability scanning
+6. **go-licenses** — License compliance checking
+
+The CI matrix tests against Go 1.25 and 1.26. The package uses only the
+Go standard library, so the dependency audit is minimal.

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -128,4 +128,5 @@ nav:
       - Developer Setup: development/developer-setup.md
       - Contributing: development/contributing.md
       - Local MQ Container: development/local-mq-container.md
+      - Quality Gates: development/quality-gates.md
   - AI Engineering: ai-engineering.md


### PR DESCRIPTION
# Pull Request

## Summary

- Add quality gates page to the docs site under Development, including the shared fragment from mq-rest-admin-common
- Append Go-specific validation pipeline details (go vet, golangci-lint, race detection, govulncheck, go-licenses)

## Issue Linkage

- Fixes #35

## Testing

- `mkdocs build -f docs/site/mkdocs.yml --strict` passes
- Docs-only: tests skipped
- Files changed: `docs/site/docs/development/quality-gates.md`, `docs/site/mkdocs.yml`

## Notes

- Shared content pulled from `mq-rest-admin-common` via `--8<-- "development/quality-gates.md"`