### PR TITLE
fix: propagate 4 missing mapping entries from canonical JSON

### DIFF
--- a/mqrestadmin/mapping-data.json
+++ b/mqrestadmin/mapping-data.json
@@ -1191,13 +1191,16 @@
         "APPLDESC": "application_description",
         "APPLTAG": "application_tag",
         "APPLTYPE": "application_type",
+        "ASTATE": "asynchronous_state",
         "CHANNEL": "channel_name",
         "CLIENTID": "client_id",
+        "CONN": "connection_id",
         "CONNAME": "connection_name",
         "CONNOPTS": "connection_options",
         "CONNTAG": "connection_tag",
         "DEST": "destination",
         "DESTQMGR": "destination_queue_manager",
+        "EXTCONN": "connection_prefix",
         "EXTURID": "unit_of_work_id",
         "HSTATE": "handle_state",
         "OBJNAME": "object_name",
@@ -2088,7 +2091,8 @@
     },
     "qstatus": {
       "request_key_map": {
-        "command_scope": "CMDSCOPE"
+        "command_scope": "CMDSCOPE",
+        "type": "TYPE"
       },
       "request_value_map": {},
       "response_key_map": {


### PR DESCRIPTION
# Pull Request

## Summary

- Propagate corrected `mapping-data.json` from mq-rest-admin-common#40
- Restores 3 entries in `conn.response_key_map` and 1 in `qstatus.request_key_map`

## Issue Linkage

- Fixes #38

## Testing

- `go test -race -count=1 ./...`

## Notes

- JSON is identical to canonical source in mq-rest-admin-common