### PR TITLE
feat: add version constant set to 1.1.0

### DIFF
--- a/mqrestadmin/version.go
+++ b/mqrestadmin/version.go
@@ -1,0 +1,4 @@
+package mqrestadmin
+
+// Version is the semantic version of this library.
+const Version = "1.1.0"


### PR DESCRIPTION
## Summary

- Adds a package-level `Version` constant (`1.1.0`) in `mqrestadmin/version.go` in preparation for the first published release of the library.

## Issue Linkage

- Ref #40

## Testing

- `go vet ./...` — pass
- `go test -race -count=1 ./...` — pass
- `go test -race -count=1 -tags=integration ./...` — pass

## Notes

- `golangci-lint` and `govulncheck` not available locally; CI will validate.