### PR TITLE
feat: replace go-ignore-cov with go-test-coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,21 +139,13 @@ jobs:
         if: needs.docs-only.outputs.docs-only != 'true'
         run: go test -race -count=1 -coverprofile=coverage.out ./...
 
-      - name: Install go-ignore-cov
+      - name: Install go-test-coverage
         if: needs.docs-only.outputs.docs-only != 'true'
-        run: go install github.com/hexira/go-ignore-cov@v0.3.0
+        run: go install github.com/vladopajic/go-test-coverage/v2@latest
 
       - name: Enforce 100% coverage (excluding annotated lines)
         if: needs.docs-only.outputs.docs-only != 'true'
-        run: |
-          go-ignore-cov --file coverage.out
-          COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | tr -d '%')
-          echo "Coverage after exclusions: ${COVERAGE}%"
-          if [ "$(echo "$COVERAGE < 100.0" | bc)" -eq 1 ]; then
-            echo "FAIL: coverage is ${COVERAGE}%, required 100%"
-            go tool cover -func=coverage.out | grep -v '100.0%'
-            exit 1
-          fi
+        run: go-test-coverage --config .testcoverage.yml
 
   codeql:
     name: codeql

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -1,0 +1,5 @@
+profile: coverage.out
+threshold:
+  file: 100
+  package: 100
+  total: 100

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,11 +61,11 @@ go tool cover -html=coverage.out                # View coverage in browser
 ```
 
 - **Framework**: stdlib `testing` package
-- **Coverage**: Target 100% line coverage, enforced in CI via `go-ignore-cov`.
+- **Coverage**: Target 100% line coverage, enforced in CI via `go-test-coverage`.
   Structurally untestable lines (e.g., `json.Marshal` on `map[string]any`,
-  embedded JSON parse errors) are annotated with `//coverage:ignore` and
-  excluded from measurement. This keeps the gate tight — new untested code
-  cannot slip through.
+  embedded JSON parse errors) are annotated with `// coverage-ignore -- <reason>`
+  on the `{` line and excluded from measurement. This keeps the gate tight —
+  new untested code cannot slip through.
 
 ## Architecture
 

--- a/docs/site/docs/development/quality-gates.md
+++ b/docs/site/docs/development/quality-gates.md
@@ -17,7 +17,7 @@ This covers:
 1. **go vet** — Standard Go static analysis
 2. **golangci-lint** — Comprehensive linter suite
 3. **go test -race** — Unit tests with race detector enabled
-4. **Coverage enforcement** — 100% coverage after `go-ignore-cov` exclusions
+4. **Coverage enforcement** — 100% coverage after `go-test-coverage` exclusions
 5. **govulncheck** — Dependency vulnerability scanning
 6. **go-licenses** — License compliance checking
 

--- a/mqrestadmin/mapping.go
+++ b/mqrestadmin/mapping.go
@@ -54,8 +54,7 @@ type attributeMapper struct {
 // mapping data.
 func newAttributeMapper() (*attributeMapper, error) {
 	var data mappingData
-	if err := json.Unmarshal(mappingDataJSON, &data); err != nil {
-		//coverage:ignore
+	if err := json.Unmarshal(mappingDataJSON, &data); err != nil { // coverage-ignore -- embedded JSON is valid by construction
 		return nil, fmt.Errorf("parse mapping data: %w", err)
 	}
 	return &attributeMapper{data: &data}, nil
@@ -65,20 +64,17 @@ func newAttributeMapper() (*attributeMapper, error) {
 // overrides applied to the default mapping data.
 func newAttributeMapperWithOverrides(overrides map[string]any, mode MappingOverrideMode) (*attributeMapper, error) {
 	mapper, err := newAttributeMapper()
-	if err != nil {
-		//coverage:ignore
+	if err != nil { // coverage-ignore -- newAttributeMapper only fails on invalid embedded data
 		return nil, err
 	}
 
 	overrideBytes, err := json.Marshal(overrides)
-	if err != nil {
-		//coverage:ignore
+	if err != nil { // coverage-ignore -- json.Marshal on map[string]any cannot fail
 		return nil, fmt.Errorf("marshal mapping overrides: %w", err)
 	}
 
 	var overrideData mappingData
-	if err := json.Unmarshal(overrideBytes, &overrideData); err != nil {
-		//coverage:ignore
+	if err := json.Unmarshal(overrideBytes, &overrideData); err != nil { // coverage-ignore -- re-parsed from valid Marshal output
 		return nil, fmt.Errorf("parse mapping overrides: %w", err)
 	}
 

--- a/mqrestadmin/session.go
+++ b/mqrestadmin/session.go
@@ -193,8 +193,7 @@ func NewSession(restBaseURL, qmgrName string, credentials Credentials, opts ...O
 		} else {
 			mapper, err = newAttributeMapper()
 		}
-		if err != nil {
-			//coverage:ignore
+		if err != nil { // coverage-ignore -- mapper init only fails on invalid embedded data
 			return nil, fmt.Errorf("initialize attribute mapper: %w", err)
 		}
 	}

--- a/mqrestadmin/transport.go
+++ b/mqrestadmin/transport.go
@@ -41,8 +41,7 @@ func (transport *HTTPTransport) PostJSON(ctx context.Context, url string,
 	verifyTLS bool,
 ) (*TransportResponse, error) {
 	body, err := json.Marshal(payload)
-	if err != nil {
-		//coverage:ignore
+	if err != nil { // coverage-ignore -- json.Marshal on map[string]any cannot fail
 		return nil, &TransportError{URL: url, Err: fmt.Errorf("marshal payload: %w", err)}
 	}
 
@@ -64,8 +63,7 @@ func (transport *HTTPTransport) PostJSON(ctx context.Context, url string,
 	defer func() { _ = response.Body.Close() }()
 
 	responseBody, err := io.ReadAll(response.Body)
-	if err != nil {
-		//coverage:ignore
+	if err != nil { // coverage-ignore -- io.ReadAll after successful HTTP response
 		return nil, &TransportError{URL: url, Err: fmt.Errorf("read response: %w", err)}
 	}
 


### PR DESCRIPTION
## Summary

- Replaces `go-ignore-cov` v0.3.0 with `go-test-coverage` (vladopajic/go-test-coverage) for coverage exclusion and enforcement
- `go-test-coverage` uses AST-based exclusion that is structurally immune to the column-matching bug in `go-ignore-cov` (#45)
- Migrates 7 annotations from `//coverage:ignore` to `// coverage-ignore -- <reason>` with explanatory text
- Simplifies CI from 3-step shell pipeline to single `go-test-coverage --config .testcoverage.yml` invocation

## Issue Linkage

- Ref #45

## Testing

- `go vet ./...` — pass
- `go test -race -count=1 ./...` — pass
- `go test -race -count=1 -tags=integration ./...` — pass
- `go-test-coverage --config .testcoverage.yml` — 100% (705/705 statements)

## Notes

- Annotation syntax changed from `//coverage:ignore` (colon, inside block) to `// coverage-ignore -- <reason>` (hyphen, on the `{` line)
- All annotations now include explanatory text documenting why the line is excluded