### PR TITLE
fix: install prepare_release.py and bump version to 1.1.1

### DIFF
--- a/mqrestadmin/version.go
+++ b/mqrestadmin/version.go
@@ -1,4 +1,4 @@
 package mqrestadmin
 
 // Version is the semantic version of this library.
-const Version = "1.1.0"
+const Version = "1.1.1"


### PR DESCRIPTION
## Summary

- Add shared `prepare_release.py` script for automated releases
- Bump develop version from 1.1.0 to 1.1.1 to restore the post-publish invariant (develop must be ahead of the latest tag)

Both are prerequisites for the `/publish` skill to pass its preflight checks.

Fixes #51

## Test plan

- [ ] CI passes (build, vet, test, coverage)
- [ ] `scripts/dev/prepare_release.py` detects Go ecosystem and reads version 1.1.1
- [ ] `/publish` preflight passes both new abort conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)