### PR TITLE
fix: rename integration-test job to integration-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,8 +195,8 @@ jobs:
         with:
           language: golang
 
-  integration-test:
-    name: integration-test
+  integration-tests:
+    name: integration-tests
     runs-on: ubuntu-latest
     needs: docs-only
     if: needs.docs-only.outputs.docs-only != 'true'


### PR DESCRIPTION
## Summary

- Renames the `integration-test` CI job to `integration-tests` (plural)
- Aligns Go repo with Java repo which already uses `integration-tests`
- Part of cross-repo CI standardization before migrating to GitHub rulesets

## Test plan

- [ ] CI passes on this PR (the old `integration-test` check name in legacy branch protection will be updated separately via API)

Generated with [Claude Code](https://claude.com/claude-code)