### PR TITLE
fix: add cliff.toml for markdownlint-compliant changelog generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,82 +1,75 @@
-## [develop-v1.1.3] - 2026-02-16
+# Changelog
 
-### 🐛 Bug Fixes
+All notable changes to this project will be documented in this file.
 
-- Remove PR_BUMP_TOKEN and add issue linkage to bump PR (#66)
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
 
-### ⚙️ Miscellaneous Tasks
+## [1.1.4] - 2026-02-16
 
-- Bump version to 1.1.3 (#64)
-- Update CI action versions for next development cycle (#65)
+### Bug fixes
 
-## [develop-v1.1.2] - 2026-02-16
+- sync prepare_release.py with canonical version
+- sync prepare_release.py merge message fix from canonical (#74)
 
-### 🐛 Bug Fixes
+## [1.1.3] - 2026-02-16
 
-- Remove duplicate CI runs and relax coverage threshold (#60)
+### Bug fixes
 
-### ⚙️ Miscellaneous Tasks
+- remove PR_BUMP_TOKEN and add issue linkage to bump PR (#66)
 
-- Bump version to 1.1.2 (#61)
+## [1.1.2] - 2026-02-16
 
-## [develop-v1.1.1] - 2026-02-16
+### Bug fixes
 
-### 🚀 Features
+- remove duplicate CI runs and relax coverage threshold (#60)
+
+## [1.1.1] - 2026-02-16
+
+### Bug fixes
+
+- resolve golangci-lint issues in auth tests
+- disable MD041 for mkdocs snippet-include files
+- correct snippets base_path resolution for fragment includes (#33)
+- run mike from repo root so snippet base_path resolves in CI (#34)
+- propagate 4 missing mapping entries from canonical JSON (#39)
+- move coverage:ignore annotations to preceding line (#44)
+- set docs default version to latest on main deploy
+- install prepare_release.py and bump version to 1.1.1
+- allow commits on release/* branches in library-release model
+- rename integration-test job to integration-tests (#56)
+
+### Documentation
+
+- normalize README formatting (#3)
+- expand README with installation, quick start, and API overview (#8)
+- update implementation progress for phases 6-7 (#10)
+- update coverage target from 100% to 99%
+- add MkDocs Material documentation site (#16)
+- fix hallucinated API references and correct ensure method count (#19)
+- address medium-severity documentation consistency findings (#21)
+- address cross-library documentation consistency nits (#25)
+- switch to shared fragment includes from common repo (#30)
+- add quality gates documentation page
+
+### Features
 
 - Go port of pymqrest (mq-rest-admin-go) (#1)
-- Add CI/CD workflow, git hooks, and linter configuration (#2)
-- Add Tier 1 security tooling (CodeQL, license compliance)
-- Add Trivy and Semgrep CI jobs
-- Add version constant set to 1.1.0 (#41)
-- Replace go-ignore-cov with go-test-coverage (#46)
-- Add publish workflow and versioned docs deployment (#52)
+- add CI/CD workflow, git hooks, and linter configuration (#2)
+- add Tier 1 security tooling (CodeQL, license compliance)
+- add Trivy and Semgrep CI jobs
+- add version constant set to 1.1.0 (#41)
+- replace go-ignore-cov with go-test-coverage (#46)
+- add publish workflow and versioned docs deployment (#52)
 
-### 🐛 Bug Fixes
+### Refactoring
 
-- Resolve golangci-lint issues in auth tests
-- Disable MD041 for mkdocs snippet-include files
-- Correct snippets base_path resolution for fragment includes (#33)
-- Run mike from repo root so snippet base_path resolves in CI (#34)
-- Propagate 4 missing mapping entries from canonical JSON (#39)
-- Move coverage:ignore annotations to preceding line (#44)
-- Set docs default version to latest on main deploy
-- Install prepare_release.py and bump version to 1.1.1
-- Allow commits on release/* branches in library-release model
-- Rename integration-test job to integration-tests (#56)
+- rename package from mqrest to mqrestadmin (#6)
 
-### 🚜 Refactor
+### Testing
 
-- Rename package from mqrest to mqrestadmin (#6)
-
-### 📚 Documentation
-
-- Normalize README formatting (#3)
-- Expand README with installation, quick start, and API overview (#8)
-- Update implementation progress for phases 6-7 (#10)
-- Update coverage target from 100% to 99%
-- Add MkDocs Material documentation site (#16)
-- Fix hallucinated API references and correct ensure method count (#19)
-- Address medium-severity documentation consistency findings (#21)
-- Address cross-library documentation consistency nits (#25)
-- Switch to shared fragment includes from common repo (#30)
-- Add quality gates documentation page
-
-### 🧪 Testing
-
-- Add table-driven tests for all command wrapper methods
-- Add ensure and sync wrapper coverage
-- Add mapping edge case coverage
-- Add HTTPTransport and buildClient coverage
-- Cover auth, session init, errors, and remaining edge cases
-
-### ⚙️ Miscellaneous Tasks
-
-- Enforce 100% coverage gate with go-ignore-cov exclusion annotations (#14)
-- Add workflow_dispatch trigger to docs workflow (#17)
-- Restrict docs deploy to main branch and manual dispatch (#23)
-- Add mike versioned documentation deployment (#27)
-- Trigger dev docs deployment on push to develop (#28)
-- Trigger CI re-run with updated PR body
-- Trigger CI re-run with updated PR body
-- Improve CLAUDE.md with accurate commands and workflow docs (#50)
-- Re-trigger CI with issue linkage
+- add table-driven tests for all command wrapper methods
+- add ensure and sync wrapper coverage
+- add mapping edge case coverage
+- add HTTPTransport and buildClient coverage
+- cover auth, session init, errors, and remaining edge cases

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,45 @@
+[changelog]
+header = """# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
+"""
+body = """
+
+{% if version -%}
+    ## [{{ version | trim_start_matches(pat="develop-v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+    ## [Unreleased]
+{% endif -%}
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - {{ commit.message | split(pat="\n") | first | trim }}\
+    {% endfor %}
+{% endfor %}
+"""
+footer = ""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+commit_parsers = [
+  { message = "^feat", group = "Features" },
+  { message = "^fix", group = "Bug fixes" },
+  { message = "^doc", group = "Documentation" },
+  { message = "^perf", group = "Performance" },
+  { message = "^refactor", group = "Refactoring" },
+  { message = "^style", group = "Styling" },
+  { message = "^test", group = "Testing" },
+  { message = "^ci", group = "CI" },
+  { message = "^chore", skip = true },
+]
+protect_breaking_commits = false
+filter_commits = false
+tag_pattern = "develop-v[0-9].*"
+skip_tags = ""
+sort_commits = "oldest"


### PR DESCRIPTION
## Summary

- Add `cliff.toml` matching the Java/Python template for markdownlint-compliant changelog output
- Fixes MD022/MD032 violations (missing blank lines around headings/lists) that blocked the release branch CI
- Switches from emoji group headers to plain text and filters chore commits, consistent with other repos
- Regenerates `CHANGELOG.md` with the new template

Fixes #77

## Test plan

- [ ] Verify markdownlint passes on the regenerated CHANGELOG.md
- [ ] Confirm the changelog format matches Java/Python repos