### PR TITLE
fix: truncate docs version to major.minor

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,7 +48,7 @@ jobs:
         id: version
         run: |
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            version=$(grep -oP 'Version\s*=\s*"\K[^"]+' mqrestadmin/version.go)
+            version=$(grep -oP 'Version\s*=\s*"\K[^"]+' mqrestadmin/version.go | cut -d. -f1,2)
             echo "version=$version" >> "$GITHUB_OUTPUT"
             echo "alias=latest" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Summary

- Truncate docs version to major.minor (e.g., `1.1`) instead of full semver (e.g., `1.1.4`)
- Java and Python already do this via `cut -d. -f1,2` and `split('.')[:2]` respectively
- Adds `| cut -d. -f1,2` to the version extraction in `docs.yml`

Fixes #88

## Test plan

- [ ] Next docs deploy on main should create/update a `1.1` entry instead of a new patch-level entry
- [ ] Existing patch-level entries (1.1.0–1.1.4) can be cleaned up from gh-pages separately

Docs-only: tests skipped

Files changed: `.github/workflows/docs.yml`
