### PR TITLE
feat: use GitHub App token for bump PR to trigger CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -124,10 +124,18 @@ jobs:
             echo "needed=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Generate app token for bump PR
+        if: steps.tag_check.outputs.exists == 'false' && steps.bump_check.outputs.needed == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Create version bump PR
         if: steps.tag_check.outputs.exists == 'false' && steps.bump_check.outputs.needed == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git checkout -b "${{ steps.next_version.outputs.branch }}" origin/develop
           git merge origin/main --no-edit


### PR DESCRIPTION
## Summary

- Replace `GITHUB_TOKEN` with a GitHub App installation token in the publish workflow's bump PR step
- PRs created by `GITHUB_TOKEN` do not trigger workflow runs (GitHub security limitation)
- Uses `actions/create-github-app-token@v1` with `APP_ID` and `APP_PRIVATE_KEY` secrets

Fixes #90

See wphillipmoore/standards-and-conventions#196 for cross-repo tracking.

## Test plan

- [ ] Verify `APP_ID` and `APP_PRIVATE_KEY` secrets are configured in the repository
- [ ] Trigger a publish by merging to main and confirm the bump PR is created with the app token
- [ ] Confirm CI runs automatically on the bump PR
