### PR TITLE
chore: post-publish dependency refresh for 1.1.5

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Generate app token for bump PR
         if: steps.tag_check.outputs.exists == 'false' && steps.bump_check.outputs.needed == 'true'
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

- Update `actions/create-github-app-token` from v1 to v2 in publish workflow

All other toolchain dependencies are already at their latest versions:
- `actions/checkout@v6`, `actions/setup-go@v6`, `actions/setup-python@v6` — current
- `golangci/golangci-lint-action@v9` — current
- Go 1.25/1.26 CI matrix — current (1.26 released Feb 10, 2026)
- No library dependencies (stdlib only)
- No dependency anchor records

Ref #92

## Test plan

- [ ] CI validates the workflow YAML is well-formed
- [ ] Publish workflow continues to work on next release (v2 is backwards-compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)