### PR TITLE
feat: add canonical local validation script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ go vet ./...            # Static analysis
 ### Validation
 
 ```bash
+scripts/dev/validate_local.sh   # Canonical validation (runs all checks below)
 go vet ./...                    # Static analysis
 golangci-lint run ./...         # Lint checks
 go test -race -count=1 ./...   # Unit tests with race detection

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -30,15 +30,29 @@
 - branching_model: library-release
 - release_model: artifact-publishing
 - supported_release_lines: current and previous
+- canonical_local_validation_command: scripts/dev/validate_local.sh
 
 ## Local validation
+
+Canonical local validation command:
+
+```bash
+scripts/dev/validate_local.sh
+```
+
+Individual checks (run by the validation script):
 
 ```bash
 go vet ./...                    # Static analysis
 golangci-lint run ./...         # Lint checks
 go test -race -count=1 ./...   # Unit tests with race detection
-go test -race -count=1 -tags=integration ./...  # Integration tests
 govulncheck ./...               # Vulnerability scanning
+```
+
+Integration tests (require MQ environment, not included in validation script):
+
+```bash
+go test -race -count=1 -tags=integration ./...
 ```
 
 ## Tooling requirement

--- a/scripts/dev/validate_local.sh
+++ b/scripts/dev/validate_local.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Local validation script mirroring CI hard gates.
+# See: https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/repository/local-validation-scripts.md
+
+set -euo pipefail
+
+# --- Prerequisite checks ---
+
+missing=()
+for tool in go golangci-lint govulncheck; do
+    if ! command -v "$tool" &>/dev/null; then
+        missing+=("$tool")
+    fi
+done
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+    echo "ERROR: Missing required tools: ${missing[*]}" >&2
+    echo "Install with:" >&2
+    for tool in "${missing[@]}"; do
+        case "$tool" in
+            go)              echo "  brew install go" >&2 ;;
+            golangci-lint)   echo "  brew install golangci-lint" >&2 ;;
+            govulncheck)     echo "  go install golang.org/x/vuln/cmd/govulncheck@latest" >&2 ;;
+        esac
+    done
+    exit 1
+fi
+
+# --- Validation steps ---
+
+run() {
+    echo "Running: $*"
+    "$@"
+}
+
+run go vet ./...
+run golangci-lint run ./...
+run go test -race -count=1 ./...
+run govulncheck ./...


### PR DESCRIPTION
## Summary

- Add `scripts/dev/validate_local.sh` — checks prerequisites (`go`, `golangci-lint`, `govulncheck`) and runs all CI hard-gate checks as a single fail-fast command
- Add `canonical_local_validation_command` to repository profile
- Update CLAUDE.md to reference the canonical script

Fixes #103

## Test plan

- [ ] Run `scripts/dev/validate_local.sh` with all tools installed — passes
- [ ] Remove `golangci-lint` from PATH — script exits with actionable error before running any checks
- [ ] CI passes
