### PR TITLE
docs: rename mq-dev-environment references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
           go-version: "1.26"
 
       - name: Setup MQ environment
-        uses: wphillipmoore/mq-dev-environment/.github/actions/setup-mq@main
+        uses: wphillipmoore/mq-rest-admin-dev-environment/.github/actions/setup-mq@main
         with:
           project-name: mq-rest-admin-go
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ go tool cover -html=coverage.out                # View coverage in browser
   annotated with `// coverage-ignore -- <reason>` on the **preceding line** (the
   `{` line) and excluded from measurement.
 - **Integration tests**: Require `MQ_REST_ADMIN_GO_RUN_INTEGRATION=1` and a running
-  MQ container. CI uses the `wphillipmoore/mq-dev-environment` action.
+  MQ container. CI uses the `wphillipmoore/mq-rest-admin-dev-environment` action.
 
 ## Architecture
 

--- a/docs/site/docs/development/developer-setup.md
+++ b/docs/site/docs/development/developer-setup.md
@@ -19,7 +19,7 @@ mqrestadmin depends on two sibling repositories:
 | --- | --- |
 | [mq-rest-admin-go](https://github.com/wphillipmoore/mq-rest-admin-go) | This project |
 | [standards-and-conventions](https://github.com/wphillipmoore/standards-and-conventions) | Canonical project standards (referenced by `AGENTS.md` and git hooks) |
-| [mq-dev-environment](https://github.com/wphillipmoore/mq-dev-environment) | Dockerized MQ test infrastructure (local and CI) |
+| [mq-rest-admin-dev-environment](https://github.com/wphillipmoore/mq-rest-admin-dev-environment) | Dockerized MQ test infrastructure (local and CI) |
 
 ## Recommended directory layout
 
@@ -29,14 +29,14 @@ Clone all three repositories as siblings:
 ~/dev/
 ├── mq-rest-admin-go/
 ├── standards-and-conventions/
-└── mq-dev-environment/
+└── mq-rest-admin-dev-environment/
 ```
 
 ```bash
 cd ~/dev
 git clone https://github.com/wphillipmoore/mq-rest-admin-go.git
 git clone https://github.com/wphillipmoore/standards-and-conventions.git
-git clone https://github.com/wphillipmoore/mq-dev-environment.git
+git clone https://github.com/wphillipmoore/mq-rest-admin-dev-environment.git
 ```
 
 ## Building


### PR DESCRIPTION
## Summary

- Rename all `mq-dev-environment` references to `mq-rest-admin-dev-environment` in CI workflow, CLAUDE.md, and developer-setup docs
- Phase 1, Step 2 of the repository rename plan

## Issue Linkage

- Ref wphillipmoore/mq-dev-environment#14
- Work is not complete until the issue is closed.

## Testing

- markdownlint — clean on changed files

Docs-only: tests skipped

Files changed:
- `.github/workflows/ci.yml` (1 reference — `uses:` action path)
- `CLAUDE.md` (1 reference)
- `docs/site/docs/development/developer-setup.md` (3 references — table link, directory layout, clone command)

## Notes

- This is a pre-rename PR per the execution plan in the issue. It should be merged before the actual GitHub repository rename occurs.
- The CI `uses:` reference will break temporarily after merge until the repo is actually renamed (Phase 2). This is expected per the execution plan.