### PR TITLE
feat: apply gofmt -s simplifications for goreportcard.com compliance

### DIFF
--- a/mqrestadmin/ensure_test.go
+++ b/mqrestadmin/ensure_test.go
@@ -284,20 +284,48 @@ func TestEnsureWrappers_Created(t *testing.T) {
 	}
 
 	entries := []ensureEntry{
-		{"EnsureQremote", func(s *Session, ctx context.Context, name string, params map[string]any) (EnsureResult, error) { return s.EnsureQremote(ctx, name, params) }},
-		{"EnsureQalias", func(s *Session, ctx context.Context, name string, params map[string]any) (EnsureResult, error) { return s.EnsureQalias(ctx, name, params) }},
-		{"EnsureQmodel", func(s *Session, ctx context.Context, name string, params map[string]any) (EnsureResult, error) { return s.EnsureQmodel(ctx, name, params) }},
-		{"EnsureChannel", func(s *Session, ctx context.Context, name string, params map[string]any) (EnsureResult, error) { return s.EnsureChannel(ctx, name, params) }},
-		{"EnsureAuthinfo", func(s *Session, ctx context.Context, name string, params map[string]any) (EnsureResult, error) { return s.EnsureAuthinfo(ctx, name, params) }},
-		{"EnsureListener", func(s *Session, ctx context.Context, name string, params map[string]any) (EnsureResult, error) { return s.EnsureListener(ctx, name, params) }},
-		{"EnsureNamelist", func(s *Session, ctx context.Context, name string, params map[string]any) (EnsureResult, error) { return s.EnsureNamelist(ctx, name, params) }},
-		{"EnsureProcess", func(s *Session, ctx context.Context, name string, params map[string]any) (EnsureResult, error) { return s.EnsureProcess(ctx, name, params) }},
-		{"EnsureService", func(s *Session, ctx context.Context, name string, params map[string]any) (EnsureResult, error) { return s.EnsureService(ctx, name, params) }},
-		{"EnsureTopic", func(s *Session, ctx context.Context, name string, params map[string]any) (EnsureResult, error) { return s.EnsureTopic(ctx, name, params) }},
-		{"EnsureSub", func(s *Session, ctx context.Context, name string, params map[string]any) (EnsureResult, error) { return s.EnsureSub(ctx, name, params) }},
-		{"EnsureStgclass", func(s *Session, ctx context.Context, name string, params map[string]any) (EnsureResult, error) { return s.EnsureStgclass(ctx, name, params) }},
-		{"EnsureComminfo", func(s *Session, ctx context.Context, name string, params map[string]any) (EnsureResult, error) { return s.EnsureComminfo(ctx, name, params) }},
-		{"EnsureCfstruct", func(s *Session, ctx context.Context, name string, params map[string]any) (EnsureResult, error) { return s.EnsureCfstruct(ctx, name, params) }},
+		{"EnsureQremote", func(s *Session, ctx context.Context, name string, params map[string]any) (EnsureResult, error) {
+			return s.EnsureQremote(ctx, name, params)
+		}},
+		{"EnsureQalias", func(s *Session, ctx context.Context, name string, params map[string]any) (EnsureResult, error) {
+			return s.EnsureQalias(ctx, name, params)
+		}},
+		{"EnsureQmodel", func(s *Session, ctx context.Context, name string, params map[string]any) (EnsureResult, error) {
+			return s.EnsureQmodel(ctx, name, params)
+		}},
+		{"EnsureChannel", func(s *Session, ctx context.Context, name string, params map[string]any) (EnsureResult, error) {
+			return s.EnsureChannel(ctx, name, params)
+		}},
+		{"EnsureAuthinfo", func(s *Session, ctx context.Context, name string, params map[string]any) (EnsureResult, error) {
+			return s.EnsureAuthinfo(ctx, name, params)
+		}},
+		{"EnsureListener", func(s *Session, ctx context.Context, name string, params map[string]any) (EnsureResult, error) {
+			return s.EnsureListener(ctx, name, params)
+		}},
+		{"EnsureNamelist", func(s *Session, ctx context.Context, name string, params map[string]any) (EnsureResult, error) {
+			return s.EnsureNamelist(ctx, name, params)
+		}},
+		{"EnsureProcess", func(s *Session, ctx context.Context, name string, params map[string]any) (EnsureResult, error) {
+			return s.EnsureProcess(ctx, name, params)
+		}},
+		{"EnsureService", func(s *Session, ctx context.Context, name string, params map[string]any) (EnsureResult, error) {
+			return s.EnsureService(ctx, name, params)
+		}},
+		{"EnsureTopic", func(s *Session, ctx context.Context, name string, params map[string]any) (EnsureResult, error) {
+			return s.EnsureTopic(ctx, name, params)
+		}},
+		{"EnsureSub", func(s *Session, ctx context.Context, name string, params map[string]any) (EnsureResult, error) {
+			return s.EnsureSub(ctx, name, params)
+		}},
+		{"EnsureStgclass", func(s *Session, ctx context.Context, name string, params map[string]any) (EnsureResult, error) {
+			return s.EnsureStgclass(ctx, name, params)
+		}},
+		{"EnsureComminfo", func(s *Session, ctx context.Context, name string, params map[string]any) (EnsureResult, error) {
+			return s.EnsureComminfo(ctx, name, params)
+		}},
+		{"EnsureCfstruct", func(s *Session, ctx context.Context, name string, params map[string]any) (EnsureResult, error) {
+			return s.EnsureCfstruct(ctx, name, params)
+		}},
 	}
 
 	for _, entry := range entries {

--- a/mqrestadmin/mock_test.go
+++ b/mqrestadmin/mock_test.go
@@ -56,7 +56,7 @@ func (transport *mockTransport) addErrorResponse(err error) {
 func (transport *mockTransport) addSuccessResponse(commandResponses ...map[string]any) {
 	body := map[string]any{
 		"overallCompletionCode": float64(0),
-		"overallReasonCode":    float64(0),
+		"overallReasonCode":     float64(0),
 	}
 	if len(commandResponses) > 0 {
 		items := make([]any, len(commandResponses))
@@ -76,7 +76,7 @@ func (transport *mockTransport) addSuccessResponse(commandResponses ...map[strin
 func (transport *mockTransport) addCommandErrorResponse(completionCode, reasonCode int) {
 	body := map[string]any{
 		"overallCompletionCode": float64(completionCode),
-		"overallReasonCode":    float64(reasonCode),
+		"overallReasonCode":     float64(reasonCode),
 	}
 	transport.addResponse(200, body, nil)
 }

--- a/mqrestadmin/session.go
+++ b/mqrestadmin/session.go
@@ -15,10 +15,10 @@ const (
 	ltpaCookieName = "LtpaToken2"
 	mqscEndpoint   = "/admin/action/qmgr/%s/mqsc"
 
-	defaultTimeout       = 30 * time.Second
-	defaultCSRFToken     = "local"
-	defaultSyncTimeout   = 30 * time.Second
-	defaultPollInterval  = 1 * time.Second
+	defaultTimeout      = 30 * time.Second
+	defaultCSRFToken    = "local"
+	defaultSyncTimeout  = 30 * time.Second
+	defaultPollInterval = 1 * time.Second
 )
 
 // Session manages communication with the IBM MQ administrative REST API.
@@ -55,7 +55,7 @@ type clock interface {
 
 type systemClock struct{}
 
-func (systemClock) now() time.Time              { return time.Now() }
+func (systemClock) now() time.Time               { return time.Now() }
 func (systemClock) sleep(duration time.Duration) { time.Sleep(duration) }
 
 // Option configures a Session during construction.

--- a/mqrestadmin/session_commands_test.go
+++ b/mqrestadmin/session_commands_test.go
@@ -14,45 +14,123 @@ type displayListEntry struct {
 
 func TestDisplayListCommands(t *testing.T) {
 	entries := []displayListEntry{
-		{"DisplayApstatus", "APSTATUS", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplayApstatus(ctx, name) }},
-		{"DisplayArchive", "ARCHIVE", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplayArchive(ctx, name) }},
-		{"DisplayAuthinfo", "AUTHINFO", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplayAuthinfo(ctx, name) }},
-		{"DisplayAuthrec", "AUTHREC", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplayAuthrec(ctx, name) }},
-		{"DisplayAuthserv", "AUTHSERV", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplayAuthserv(ctx, name) }},
-		{"DisplayCfstatus", "CFSTATUS", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplayCfstatus(ctx, name) }},
-		{"DisplayCfstruct", "CFSTRUCT", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplayCfstruct(ctx, name) }},
-		{"DisplayChinit", "CHINIT", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplayChinit(ctx, name) }},
-		{"DisplayChlauth", "CHLAUTH", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplayChlauth(ctx, name) }},
-		{"DisplayChstatus", "CHSTATUS", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplayChstatus(ctx, name) }},
-		{"DisplayClusqmgr", "CLUSQMGR", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplayClusqmgr(ctx, name) }},
-		{"DisplayComminfo", "COMMINFO", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplayComminfo(ctx, name) }},
-		{"DisplayConn", "CONN", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplayConn(ctx, name) }},
-		{"DisplayEntauth", "ENTAUTH", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplayEntauth(ctx, name) }},
-		{"DisplayGroup", "GROUP", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplayGroup(ctx, name) }},
-		{"DisplayListener", "LISTENER", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplayListener(ctx, name) }},
-		{"DisplayLog", "LOG", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplayLog(ctx, name) }},
-		{"DisplayLsstatus", "LSSTATUS", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplayLsstatus(ctx, name) }},
-		{"DisplayMaxsmsgs", "MAXSMSGS", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplayMaxsmsgs(ctx, name) }},
-		{"DisplayNamelist", "NAMELIST", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplayNamelist(ctx, name) }},
-		{"DisplayPolicy", "POLICY", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplayPolicy(ctx, name) }},
-		{"DisplayProcess", "PROCESS", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplayProcess(ctx, name) }},
-		{"DisplayPubsub", "PUBSUB", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplayPubsub(ctx, name) }},
-		{"DisplayQstatus", "QSTATUS", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplayQstatus(ctx, name) }},
-		{"DisplaySbstatus", "SBSTATUS", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplaySbstatus(ctx, name) }},
-		{"DisplaySecurity", "SECURITY", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplaySecurity(ctx, name) }},
-		{"DisplayService", "SERVICE", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplayService(ctx, name) }},
-		{"DisplaySmds", "SMDS", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplaySmds(ctx, name) }},
-		{"DisplaySmdsconn", "SMDSCONN", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplaySmdsconn(ctx, name) }},
-		{"DisplayStgclass", "STGCLASS", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplayStgclass(ctx, name) }},
-		{"DisplaySub", "SUB", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplaySub(ctx, name) }},
-		{"DisplaySvstatus", "SVSTATUS", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplaySvstatus(ctx, name) }},
-		{"DisplaySystem", "SYSTEM", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplaySystem(ctx, name) }},
-		{"DisplayTcluster", "TCLUSTER", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplayTcluster(ctx, name) }},
-		{"DisplayThread", "THREAD", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplayThread(ctx, name) }},
-		{"DisplayTopic", "TOPIC", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplayTopic(ctx, name) }},
-		{"DisplayTpstatus", "TPSTATUS", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplayTpstatus(ctx, name) }},
-		{"DisplayTrace", "TRACE", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplayTrace(ctx, name) }},
-		{"DisplayUsage", "USAGE", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) { return s.DisplayUsage(ctx, name) }},
+		{"DisplayApstatus", "APSTATUS", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplayApstatus(ctx, name)
+		}},
+		{"DisplayArchive", "ARCHIVE", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplayArchive(ctx, name)
+		}},
+		{"DisplayAuthinfo", "AUTHINFO", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplayAuthinfo(ctx, name)
+		}},
+		{"DisplayAuthrec", "AUTHREC", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplayAuthrec(ctx, name)
+		}},
+		{"DisplayAuthserv", "AUTHSERV", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplayAuthserv(ctx, name)
+		}},
+		{"DisplayCfstatus", "CFSTATUS", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplayCfstatus(ctx, name)
+		}},
+		{"DisplayCfstruct", "CFSTRUCT", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplayCfstruct(ctx, name)
+		}},
+		{"DisplayChinit", "CHINIT", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplayChinit(ctx, name)
+		}},
+		{"DisplayChlauth", "CHLAUTH", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplayChlauth(ctx, name)
+		}},
+		{"DisplayChstatus", "CHSTATUS", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplayChstatus(ctx, name)
+		}},
+		{"DisplayClusqmgr", "CLUSQMGR", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplayClusqmgr(ctx, name)
+		}},
+		{"DisplayComminfo", "COMMINFO", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplayComminfo(ctx, name)
+		}},
+		{"DisplayConn", "CONN", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplayConn(ctx, name)
+		}},
+		{"DisplayEntauth", "ENTAUTH", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplayEntauth(ctx, name)
+		}},
+		{"DisplayGroup", "GROUP", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplayGroup(ctx, name)
+		}},
+		{"DisplayListener", "LISTENER", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplayListener(ctx, name)
+		}},
+		{"DisplayLog", "LOG", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplayLog(ctx, name)
+		}},
+		{"DisplayLsstatus", "LSSTATUS", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplayLsstatus(ctx, name)
+		}},
+		{"DisplayMaxsmsgs", "MAXSMSGS", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplayMaxsmsgs(ctx, name)
+		}},
+		{"DisplayNamelist", "NAMELIST", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplayNamelist(ctx, name)
+		}},
+		{"DisplayPolicy", "POLICY", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplayPolicy(ctx, name)
+		}},
+		{"DisplayProcess", "PROCESS", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplayProcess(ctx, name)
+		}},
+		{"DisplayPubsub", "PUBSUB", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplayPubsub(ctx, name)
+		}},
+		{"DisplayQstatus", "QSTATUS", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplayQstatus(ctx, name)
+		}},
+		{"DisplaySbstatus", "SBSTATUS", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplaySbstatus(ctx, name)
+		}},
+		{"DisplaySecurity", "SECURITY", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplaySecurity(ctx, name)
+		}},
+		{"DisplayService", "SERVICE", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplayService(ctx, name)
+		}},
+		{"DisplaySmds", "SMDS", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplaySmds(ctx, name)
+		}},
+		{"DisplaySmdsconn", "SMDSCONN", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplaySmdsconn(ctx, name)
+		}},
+		{"DisplayStgclass", "STGCLASS", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplayStgclass(ctx, name)
+		}},
+		{"DisplaySub", "SUB", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplaySub(ctx, name)
+		}},
+		{"DisplaySvstatus", "SVSTATUS", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplaySvstatus(ctx, name)
+		}},
+		{"DisplaySystem", "SYSTEM", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplaySystem(ctx, name)
+		}},
+		{"DisplayTcluster", "TCLUSTER", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplayTcluster(ctx, name)
+		}},
+		{"DisplayThread", "THREAD", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplayThread(ctx, name)
+		}},
+		{"DisplayTopic", "TOPIC", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplayTopic(ctx, name)
+		}},
+		{"DisplayTpstatus", "TPSTATUS", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplayTpstatus(ctx, name)
+		}},
+		{"DisplayTrace", "TRACE", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplayTrace(ctx, name)
+		}},
+		{"DisplayUsage", "USAGE", func(s *Session, ctx context.Context, name string) ([]map[string]any, error) {
+			return s.DisplayUsage(ctx, name)
+		}},
 	}
 
 	for _, entry := range entries {

--- a/mqrestadmin/session_test.go
+++ b/mqrestadmin/session_test.go
@@ -325,7 +325,7 @@ func TestMqscCommand_ExtractsParameters(t *testing.T) {
 func TestMqscCommand_FlattensNestedObjects(t *testing.T) {
 	transport := newMockTransport()
 	transport.addSuccessResponse(map[string]any{
-		"CONN":   "CONN1",
+		"CONN": "CONN1",
 		"objects": []any{
 			map[string]any{"OBJNAME": "Q1", "OBJTYPE": "QUEUE"},
 			map[string]any{"OBJNAME": "Q2", "OBJTYPE": "QUEUE"},
@@ -672,7 +672,7 @@ func TestWithResponseParameters(t *testing.T) {
 func TestMqscCommand_MappingStrictResponseError(t *testing.T) {
 	transport := newMockTransport()
 	transport.addSuccessResponse(map[string]any{
-		"QUEUE":      "TEST.Q",
+		"QUEUE":       "TEST.Q",
 		"UNKNOWNATTR": "value",
 	})
 	session := newTestSessionWithMapping(transport)
@@ -735,7 +735,7 @@ func TestMqscCommand_PerItemCommandError(t *testing.T) {
 	// Overall codes OK, but per-item has error
 	body := map[string]any{
 		"overallCompletionCode": float64(0),
-		"overallReasonCode":    float64(0),
+		"overallReasonCode":     float64(0),
 		"commandResponse": []any{
 			map[string]any{
 				"completionCode": float64(2),


### PR DESCRIPTION
# Pull Request

## Summary

- Apply `gofmt -s` simplifications across 5 files to achieve 100% gofmt score on goreportcard.com
- Changes are purely formatting: composite literal simplification and column alignment normalization

## Issue Linkage

- Fixes #111

## Testing

- `go vet ./...`
- `go test -race -count=1 ./...`

## Notes

- No functional changes; all modifications are whitespace/formatting only