### PR TITLE
feat: reduce mqscCommand cyclomatic complexity for goreportcard.com

### DIFF
--- a/mqrestadmin/session.go
+++ b/mqrestadmin/session.go
@@ -279,12 +279,12 @@ func (session *Session) mqscCommand(ctx context.Context, command, mqscQualifier 
 // attribute names and response parameter names from snake_case to MQSC names.
 func (session *Session) applyRequestMapping(command, qualifier string,
 	params map[string]any, responseParameters []string,
-) (string, map[string]any, []string, error) {
+) (mappingQualifier string, mappedParams map[string]any, mappedResponseParams []string, err error) {
 	if !session.mapAttributes || session.mapper == nil {
 		return "", params, responseParameters, nil
 	}
 
-	mappingQualifier := session.mapper.resolveMappingQualifier(command, qualifier)
+	mappingQualifier = session.mapper.resolveMappingQualifier(command, qualifier)
 
 	// Map request attributes
 	if len(params) > 0 && mappingQualifier != "" {


### PR DESCRIPTION
# Pull Request

## Summary

- Extract three helper methods from `mqscCommand` to reduce cyclomatic complexity from 24 to 6
- Extracted: `applyRequestMapping` (10), `executeAndParseResponse` (5), `applyResponseMapping` (7)
- All functions now well below the gocyclo threshold of 15

## Issue Linkage

- Fixes #112

## Testing

- `go vet ./...`
- `go test -race -count=1 ./...`

## Notes

- Pure refactoring with no behavioral changes; all existing tests pass unmodified