### PR TITLE
chore: sync tooling and add commit/PR wrapper script instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,41 @@ pre-configured responses. Helper constructors:
 - **Pre-flight**: Always check branch with `git status -sb` before modifying files. If on `develop`, create a `feature/*` branch first.
 - **Go version gate**: PRs to `develop` must have a `go.mod` version different from `main`
 
+## Commit and PR Scripts
+
+**NEVER use raw `git commit`** — always use `scripts/dev/commit.sh`.
+**NEVER use raw `gh pr create`** — always use `scripts/dev/submit-pr.sh`.
+
+### Committing
+
+```bash
+scripts/dev/commit.sh --type feat --scope mapping --message "add reverse lookup" --agent claude
+scripts/dev/commit.sh --type fix --message "correct off-by-one in polling" --agent claude
+scripts/dev/commit.sh --type docs --message "update README examples" --body "Expanded usage section" --agent claude
+```
+
+- `--type` (required): `feat|fix|docs|style|refactor|test|chore|ci|build`
+- `--message` (required): commit description
+- `--agent` (required): `claude` or `codex` — resolves the correct `Co-Authored-By` identity
+- `--scope` (optional): conventional commit scope
+- `--body` (optional): detailed commit body
+
+### Submitting PRs
+
+```bash
+scripts/dev/submit-pr.sh --issue 42 --summary "Add reverse lookup for attribute mapping"
+scripts/dev/submit-pr.sh --issue 42 --linkage Ref --summary "Update docs" --docs-only
+scripts/dev/submit-pr.sh --issue 42 --summary "Fix polling bug" --notes "Tested with MQ 9.4"
+```
+
+- `--issue` (required): GitHub issue number (just the number)
+- `--summary` (required): one-line PR summary
+- `--linkage` (optional, default: `Fixes`): `Fixes|Closes|Resolves|Ref`
+- `--title` (optional): PR title (default: most recent commit subject)
+- `--notes` (optional): additional notes
+- `--docs-only` (optional): applies docs-only testing exception
+- `--dry-run` (optional): print generated PR without executing
+
 ## Key References
 
 **Canonical Standards**: <https://github.com/wphillipmoore/standards-and-conventions>

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -73,6 +73,52 @@ Required for daily workflow:
   - Feature PRs: `gh pr merge --auto --squash --delete-branch`
   - Release PRs: `gh pr merge --auto --merge --delete-branch`
 
+## Commit and PR scripts
+
+AI agents **must** use the wrapper scripts for commits and PR
+submission. Do not construct commit messages or PR bodies manually.
+
+### Committing
+
+```bash
+scripts/dev/commit.sh \
+  --type TYPE --message MESSAGE --agent AGENT \
+  [--scope SCOPE] [--body BODY]
+```
+
+- `--type` (required): one of
+  `feat|fix|docs|style|refactor|test|chore|ci|build`
+- `--message` (required): commit description
+- `--agent` (required): `claude` or `codex`
+- `--scope` (optional): conventional commit scope
+- `--body` (optional): detailed commit body
+
+The script resolves the correct `Co-Authored-By` identity from the
+[AI co-authors](#ai-co-authors) section and the git hooks validate
+the result.
+
+### Submitting PRs
+
+```bash
+scripts/dev/submit-pr.sh \
+  --issue NUMBER --summary TEXT \
+  [--linkage KEYWORD] [--title TEXT] \
+  [--notes TEXT] [--docs-only] [--dry-run]
+```
+
+- `--issue` (required): GitHub issue number (just the number)
+- `--summary` (required): one-line PR summary
+- `--linkage` (optional, default: `Fixes`):
+  `Fixes|Closes|Resolves|Ref`
+- `--title` (optional): PR title (default: most recent commit
+  subject)
+- `--notes` (optional): additional notes
+- `--docs-only` (optional): applies docs-only testing exception
+- `--dry-run` (optional): print generated PR without executing
+
+The script detects the target branch and merge strategy
+automatically.
+
 ## Approved domain abbreviations
 
 Domain-specific abbreviations that are well-established in the IBM MQ ecosystem

--- a/scripts/dev/commit.sh
+++ b/scripts/dev/commit.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Commit wrapper that constructs standards-compliant commit messages.
+# Resolves Co-Authored-By identities from docs/repository-standards.md.
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+
+# --- Defaults ---
+type=""
+scope=""
+message=""
+body=""
+agent=""
+
+# --- Argument parsing ---
+usage() {
+  cat >&2 <<'EOF'
+Usage: scripts/dev/commit.sh --type TYPE --message MESSAGE --agent AGENT [options]
+
+Required:
+  --type TYPE       Conventional commit type (feat|fix|docs|style|refactor|test|chore|ci|build)
+  --message MESSAGE Commit description (text after "type: ")
+  --agent AGENT     AI tool identity: claude or codex
+
+Optional:
+  --scope SCOPE     Conventional commit scope
+  --body BODY       Detailed commit body
+  -h, --help        Show this help
+EOF
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --type)    type="$2";    shift 2 ;;
+    --scope)   scope="$2";   shift 2 ;;
+    --message) message="$2"; shift 2 ;;
+    --body)    body="$2";    shift 2 ;;
+    --agent)   agent="$2";   shift 2 ;;
+    -h|--help) usage ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      usage
+      ;;
+  esac
+done
+
+# --- Validation ---
+
+# Required arguments.
+if [[ -z "$type" ]]; then
+  echo "ERROR: --type is required." >&2
+  usage
+fi
+if [[ -z "$message" ]]; then
+  echo "ERROR: --message is required." >&2
+  usage
+fi
+if [[ -z "$agent" ]]; then
+  echo "ERROR: --agent is required." >&2
+  usage
+fi
+
+# Validate type.
+allowed_types="feat|fix|docs|style|refactor|test|chore|ci|build"
+if [[ ! "$type" =~ ^(feat|fix|docs|style|refactor|test|chore|ci|build)$ ]]; then
+  echo "ERROR: invalid --type '$type'. Allowed: $allowed_types" >&2
+  exit 1
+fi
+
+# Resolve agent identity from docs/repository-standards.md.
+profile_file="$repo_root/docs/repository-standards.md"
+if [[ ! -f "$profile_file" ]]; then
+  echo "ERROR: repository profile not found at $profile_file" >&2
+  exit 1
+fi
+
+# Look for the identity whose username contains -<agent> (e.g., -claude, -codex).
+identity=""
+while IFS= read -r line; do
+  # Lines look like: - Co-Authored-By: name <email>
+  stripped="${line#- }"
+  if echo "$stripped" | grep -qi "\-${agent}[[:space:]]"; then
+    identity="$stripped"
+    break
+  fi
+done < <(grep -i '^\- Co-Authored-By:' "$profile_file" || true)
+
+if [[ -z "$identity" ]]; then
+  echo "ERROR: no approved identity found for agent '$agent' in $profile_file." >&2
+  echo "Approved identities are listed under 'AI co-authors'." >&2
+  exit 1
+fi
+
+# Verify there are staged changes.
+if git diff --cached --quiet; then
+  echo "ERROR: no staged changes. Stage files with 'git add' before committing." >&2
+  exit 1
+fi
+
+# --- Construct commit message ---
+subject="$type"
+if [[ -n "$scope" ]]; then
+  subject="${subject}(${scope})"
+fi
+subject="${subject}: ${message}"
+
+# Use a temporary file to preserve formatting (per AGENTS.md guidance).
+tmp_file="$(mktemp)"
+trap 'rm -f "$tmp_file"' EXIT
+
+printf '%s\n' "$subject" > "$tmp_file"
+if [[ -n "$body" ]]; then
+  printf '\n%s\n' "$body" >> "$tmp_file"
+fi
+printf '\n%s\n' "$identity" >> "$tmp_file"
+
+# --- Commit ---
+git commit --file "$tmp_file"

--- a/scripts/dev/submit-pr.sh
+++ b/scripts/dev/submit-pr.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# PR submission wrapper that constructs standards-compliant PR bodies.
+# Populates .github/pull_request_template.md programmatically.
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+
+# --- Defaults ---
+issue=""
+linkage="Fixes"
+summary=""
+notes=""
+title=""
+docs_only=false
+dry_run=false
+
+# --- Argument parsing ---
+usage() {
+  cat >&2 <<'EOF'
+Usage: scripts/dev/submit-pr.sh --issue NUMBER --summary TEXT [options]
+
+Required:
+  --issue NUMBER    GitHub issue number (just the number, no #)
+  --summary TEXT    One-line PR summary (goes under ## Summary)
+
+Optional:
+  --linkage KEYWORD Issue linkage keyword (default: Fixes)
+                    Allowed: Fixes, Closes, Resolves, Ref
+  --notes TEXT      Additional notes for the PR
+  --title TEXT      PR title (default: most recent commit subject)
+  --docs-only       Apply docs-only exception to testing section
+  --dry-run         Print the PR body and command without executing
+  -h, --help        Show this help
+EOF
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --issue)    issue="$2";   shift 2 ;;
+    --linkage)  linkage="$2"; shift 2 ;;
+    --summary)  summary="$2"; shift 2 ;;
+    --notes)    notes="$2";   shift 2 ;;
+    --title)    title="$2";   shift 2 ;;
+    --docs-only) docs_only=true; shift ;;
+    --dry-run)  dry_run=true; shift ;;
+    -h|--help)  usage ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      usage
+      ;;
+  esac
+done
+
+# --- Validation ---
+
+if [[ -z "$issue" ]]; then
+  echo "ERROR: --issue is required." >&2
+  usage
+fi
+if [[ -z "$summary" ]]; then
+  echo "ERROR: --summary is required." >&2
+  usage
+fi
+
+# Validate issue is a positive integer.
+if [[ ! "$issue" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ERROR: --issue must be a positive integer, got '$issue'." >&2
+  exit 1
+fi
+
+# Validate linkage keyword.
+if [[ ! "$linkage" =~ ^(Fixes|Closes|Resolves|Ref)$ ]]; then
+  echo "ERROR: invalid --linkage '$linkage'. Allowed: Fixes, Closes, Resolves, Ref" >&2
+  exit 1
+fi
+
+# --- Detect branch and target ---
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
+
+if [[ "$current_branch" == release/* ]]; then
+  target_branch="main"
+  merge_strategy="--merge"
+else
+  target_branch="develop"
+  merge_strategy="--squash"
+fi
+
+# --- Generate PR title ---
+if [[ -z "$title" ]]; then
+  title="$(git log -1 --pretty=%s)"
+fi
+
+# --- Build testing section ---
+# Read the testing section from the PR template as the default.
+template_file="$repo_root/.github/pull_request_template.md"
+testing_section=""
+if [[ -f "$template_file" ]]; then
+  # Extract lines between ## Testing and the next ## heading.
+  in_testing=false
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^##[[:space:]]+Testing ]]; then
+      in_testing=true
+      continue
+    fi
+    if [[ "$in_testing" == true && "$line" =~ ^##[[:space:]] ]]; then
+      break
+    fi
+    if [[ "$in_testing" == true ]]; then
+      testing_section="${testing_section}${line}
+"
+    fi
+  done < "$template_file"
+  # Trim leading/trailing blank lines.
+  # Remove leading blank lines.
+  while [[ "$testing_section" == $'\n'* ]]; do
+    testing_section="${testing_section#$'\n'}"
+  done
+  # Remove trailing blank lines and whitespace.
+  while [[ "$testing_section" == *$'\n' ]]; do
+    testing_section="${testing_section%$'\n'}"
+  done
+fi
+
+if [[ "$docs_only" == true ]]; then
+  changed_files="$(git diff --name-only "${target_branch}...HEAD" 2>/dev/null || git diff --name-only HEAD~1)"
+  prefixed_files=""
+  while IFS= read -r file; do
+    prefixed_files="${prefixed_files}- ${file}
+"
+  done <<< "$changed_files"
+  testing_section="Docs-only: tests skipped
+
+Changed files:
+${prefixed_files%
+}"
+fi
+
+# --- Build notes section ---
+notes_section="${notes:--}"
+
+# --- Construct PR body ---
+pr_body="# Pull Request
+
+## Summary
+
+- ${summary}
+
+## Issue Linkage
+
+- ${linkage} #${issue}
+
+## Testing
+
+${testing_section}
+
+## Notes
+
+- ${notes_section}"
+
+# --- Execute or dry-run ---
+if [[ "$dry_run" == true ]]; then
+  echo "=== PR Title ==="
+  echo "$title"
+  echo ""
+  echo "=== Target Branch ==="
+  echo "$target_branch (strategy: $merge_strategy)"
+  echo ""
+  echo "=== PR Body ==="
+  echo "$pr_body"
+  exit 0
+fi
+
+# Push branch to origin.
+echo "Pushing branch '$current_branch' to origin..."
+git push -u origin "$current_branch"
+
+# Use a temporary file for the PR body to preserve formatting.
+tmp_body="$(mktemp)"
+trap 'rm -f "$tmp_body"' EXIT
+printf '%s\n' "$pr_body" > "$tmp_body"
+
+# Create PR.
+echo "Creating PR..."
+pr_url="$(gh pr create \
+  --base "$target_branch" \
+  --title "$title" \
+  --body-file "$tmp_body")"
+
+echo "PR created: $pr_url"
+
+# Enable auto-merge.
+echo "Enabling auto-merge ($merge_strategy)..."
+gh pr merge --auto "$merge_strategy" --delete-branch
+
+echo "Done. PR URL: $pr_url"

--- a/scripts/dev/sync-tooling.sh
+++ b/scripts/dev/sync-tooling.sh
@@ -24,6 +24,8 @@ MANAGED_FILES=(
   scripts/lint/markdown-standards.sh
   scripts/lint/pr-issue-linkage.sh
   scripts/lint/repo-profile.sh
+  scripts/dev/commit.sh
+  scripts/dev/submit-pr.sh
   scripts/dev/prepare_release.py
   scripts/dev/finalize_repo.sh
   scripts/dev/sync-tooling.sh


### PR DESCRIPTION
# Pull Request

## Summary

- Sync commit.sh and submit-pr.sh from standard-tooling, add usage instructions to CLAUDE.md and repository-standards.md

## Issue Linkage

- Ref #16

## Testing

- markdownlint
- `go vet ./...`
- `go test -race -count=1 ./...`

## Notes

- -
