### PR TITLE
chore: add __pycache__ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ go.work.sum
 # MkDocs build output
 docs/site/site/
 
+# Python
+__pycache__/
+
 # Editor/IDE
 # .idea/
 # .vscode/


### PR DESCRIPTION
# Pull Request

## Summary

- Add __pycache__ to .gitignore for shared Python dev tooling

## Issue Linkage

- Fixes #129

## Testing

- markdownlint
- `go vet ./...`
- `go test -race -count=1 ./...`

## Notes

- -
