### PR TITLE
chore: bump version to 1.1.8

### DIFF
--- a/mqrestadmin/version.go
+++ b/mqrestadmin/version.go
@@ -1,4 +1,4 @@
 package mqrestadmin
 
 // Version is the semantic version of this library.
-const Version = "1.1.7"
+const Version = "1.1.8"


### PR DESCRIPTION
# Pull Request

## Summary

- Bump version to 1.1.8 to replace partial v1.1.7 release

## Issue Linkage

- Fixes #135

## Testing

- markdownlint
- `go vet ./...`
- `go test -race -count=1 ./...`

## Notes

- -
