### PR TITLE
docs: add Go Report Card badge to docs landing page and quality gates

### DIFF
--- a/docs/site/docs/development/quality-gates.md
+++ b/docs/site/docs/development/quality-gates.md
@@ -23,3 +23,12 @@ This covers:
 
 The CI matrix tests against Go 1.25 and 1.26. The package uses only the
 Go standard library, so the dependency audit is minimal.
+
+## External quality report
+
+[![Go Report Card](https://goreportcard.com/badge/github.com/wphillipmoore/mq-rest-admin-go)](https://goreportcard.com/report/github.com/wphillipmoore/mq-rest-admin-go)
+
+[Go Report Card](https://goreportcard.com/report/github.com/wphillipmoore/mq-rest-admin-go)
+runs six automated checks against the codebase: go vet, gofmt, gocyclo,
+ineffassign, license, and misspell. All of these overlap with checks
+already enforced by the local validation pipeline and CI.

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -1,5 +1,7 @@
 # mqrestadmin
 
+[![Go Report Card](https://goreportcard.com/badge/github.com/wphillipmoore/mq-rest-admin-go)](https://goreportcard.com/report/github.com/wphillipmoore/mq-rest-admin-go)
+
 ## Overview
 
 **mqrestadmin** provides a Go-friendly interface to IBM MQ queue manager


### PR DESCRIPTION
# Pull Request

## Summary

- Add Go Report Card badge and link to docs landing page and quality gates page

## Issue Linkage

- Fixes #138

## Testing

Docs-only: tests skipped

Changed files:
- docs/site/docs/development/quality-gates.md
- docs/site/docs/index.md

## Notes

- -
