### PR TITLE
ci: add SonarCloud quality analysis to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,42 @@ jobs:
         with:
           language: golang
 
+  sonarcloud:
+    name: "quality: sonarcloud"
+    runs-on: ubuntu-latest
+    needs: docs-only
+    steps:
+      - name: Docs-only short-circuit
+        if: needs.docs-only.outputs.docs-only == 'true'
+        run: echo "Docs-only changes detected; skipping SonarCloud."
+
+      - name: Checkout code
+        if: needs.docs-only.outputs.docs-only != 'true'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        if: needs.docs-only.outputs.docs-only != 'true'
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+
+      - name: Run tests with coverage
+        if: needs.docs-only.outputs.docs-only != 'true'
+        run: go test -race -count=1 -coverprofile=coverage.out ./...
+
+      - name: Run SonarCloud scan
+        if: needs.docs-only.outputs.docs-only != 'true'
+        uses: wphillipmoore/standard-actions/actions/quality/sonarcloud@develop
+        with:
+          sonar-token: ${{ secrets.SONAR_TOKEN }}
+          organization: wphillipmoore
+          project-key: wphillipmoore_mq-rest-admin-go
+          sources: "."
+          tests: "."
+          extra-args: "-Dsonar.go.coverage.reportPaths=coverage.out"
+
   integration-tests:
     name: "test: integration"
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Pull Request

## Summary

- Add SonarCloud quality analysis job to CI workflow using the new composite action from standard-actions

## Issue Linkage

- Fixes #169

## Testing

- markdownlint
- `go vet ./...`
- `go test -race -count=1 ./...`

## Notes

- -