### PR TITLE
fix(ci): separate source and test paths for SonarCloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,9 +231,12 @@ jobs:
           sonar-token: ${{ secrets.SONAR_TOKEN }}
           organization: wphillipmoore
           project-key: wphillipmoore_mq-rest-admin-go
-          sources: "."
-          tests: "."
-          extra-args: "-Dsonar.go.coverage.reportPaths=coverage.out"
+          sources: "mqrestadmin"
+          tests: "mqrestadmin"
+          extra-args: >-
+            -Dsonar.go.coverage.reportPaths=coverage.out
+            -Dsonar.test.inclusions=**/*_test.go
+            -Dsonar.exclusions=**/*_test.go
 
   integration-tests:
     name: "test: integration"


### PR DESCRIPTION
# Pull Request

## Summary

- Fix SonarCloud source/test path overlap causing duplicate file indexing error

## Issue Linkage

- Fixes #169

## Testing

- markdownlint
- `go vet ./...`
- `go test -race -count=1 ./...`

## Notes

- -