### PR TITLE
ci: add Code Climate (Qlty) coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,6 +238,39 @@ jobs:
             -Dsonar.test.inclusions=**/*_test.go
             -Dsonar.exclusions=**/*_test.go
 
+  codeclimate:
+    name: "quality: codeclimate"
+    runs-on: ubuntu-latest
+    needs: docs-only
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Docs-only short-circuit
+        if: needs.docs-only.outputs.docs-only == 'true'
+        run: echo "Docs-only changes detected; skipping Code Climate."
+
+      - name: Checkout code
+        if: needs.docs-only.outputs.docs-only != 'true'
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        if: needs.docs-only.outputs.docs-only != 'true'
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+
+      - name: Run tests with coverage
+        if: needs.docs-only.outputs.docs-only != 'true'
+        run: go test -race -count=1 -coverprofile=coverage.out ./...
+
+      - name: Upload coverage to Qlty Cloud
+        if: needs.docs-only.outputs.docs-only != 'true'
+        uses: wphillipmoore/standard-actions/actions/quality/codeclimate@develop
+        with:
+          files: "coverage.out"
+          format: "coverprofile"
+
   integration-tests:
     name: "test: integration"
     runs-on: ubuntu-latest

--- a/.github/workflows/codeclimate.yml
+++ b/.github/workflows/codeclimate.yml
@@ -1,0 +1,36 @@
+name: Code Climate
+
+on:
+  push:
+    branches:
+      - develop
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: codeclimate
+  cancel-in-progress: false
+
+jobs:
+  codeclimate:
+    name: "quality: codeclimate"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+
+      - name: Run tests with coverage
+        run: go test -race -count=1 -coverprofile=coverage.out ./...
+
+      - name: Upload coverage to Qlty Cloud
+        uses: wphillipmoore/standard-actions/actions/quality/codeclimate@develop
+        with:
+          files: "coverage.out"
+          format: "coverprofile"


### PR DESCRIPTION
# Pull Request

## Summary

- Add codeclimate job to ci.yml and codeclimate.yml post-merge workflow for Qlty Cloud coverage upload via OIDC

## Issue Linkage

- Fixes #173

## Testing

- markdownlint
- `go vet ./...`
- `go test -race -count=1 ./...`

## Notes

- -