### PR TITLE
feat(ci): run integration tests with same Go version matrix as unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,6 +275,10 @@ jobs:
     name: "test: integration"
     runs-on: ubuntu-latest
     needs: docs-only
+    strategy:
+      matrix:
+        go-version: ["1.25", "1.26"]
+
     steps:
       - name: Docs-only short-circuit
         if: needs.docs-only.outputs.docs-only == 'true'
@@ -288,7 +292,7 @@ jobs:
         if: needs.docs-only.outputs.docs-only != 'true'
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: ${{ matrix.go-version }}
 
       - name: Setup MQ environment
         if: needs.docs-only.outputs.docs-only != 'true'


### PR DESCRIPTION
# Pull Request

## Summary

- Run integration tests with the same Go version matrix (1.25, 1.26) as unit tests for consistent coverage

## Issue Linkage

- Ref #85

## Testing

- markdownlint
- `go vet ./...`
- `go test -race -count=1 ./...`

## Notes

- -