### PR TITLE
chore(revive): expand revive linter from 4 to 40 rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,7 +17,43 @@ linters:
         - performance
     revive:
       rules:
+        - name: atomic
         - name: blank-imports
+        - name: bool-literal-in-expr
+        - name: call-to-gc
+        - name: confusing-naming
+        - name: constant-logical-expr
+        - name: context-as-argument
+        - name: defer
+        - name: dot-imports
+        - name: duplicated-imports
+        - name: early-return
+        - name: empty-block
+        - name: error-naming
+        - name: error-return
+        - name: errorf
         - name: exported
+        - name: identical-branches
+        - name: import-shadowing
+        - name: increment-decrement
+        - name: indent-error-flow
+        - name: modifies-parameter
+        - name: modifies-value-receiver
+        - name: package-comments
+        - name: range
+        - name: range-val-address
+        - name: range-val-in-closure
+        - name: receiver-naming
+        - name: redefines-builtin-id
+        - name: string-of-int
+        - name: superfluous-else
+        - name: time-naming
+        - name: unconditional-recursion
+        - name: unexported-return
+        - name: unnecessary-stmt
         - name: unreachable-code
         - name: unused-parameter
+        - name: use-any
+        - name: var-declaration
+        - name: var-naming
+        - name: waitgroup-by-value

--- a/mqrestadmin/mapping.go
+++ b/mqrestadmin/mapping.go
@@ -160,7 +160,7 @@ func (mapper *attributeMapper) mapResponseAttributes(qualifier string,
 // mapResponseList translates a list of response attribute maps, tracking
 // object indices in any mapping issues.
 func (mapper *attributeMapper) mapResponseList(qualifier string,
-	objects []map[string]any, strict bool,
+	objects []map[string]any,
 ) ([]map[string]any, []MappingIssue) {
 	var allIssues []MappingIssue
 	result := make([]map[string]any, len(objects))
@@ -171,9 +171,6 @@ func (mapper *attributeMapper) mapResponseList(qualifier string,
 		allIssues = append(allIssues, issues...)
 	}
 
-	if strict && len(allIssues) > 0 {
-		return result, allIssues
-	}
 	return result, allIssues
 }
 

--- a/mqrestadmin/mapping_test.go
+++ b/mqrestadmin/mapping_test.go
@@ -274,7 +274,7 @@ func TestMapResponseList(t *testing.T) {
 		{"QUEUE": "Q2", "MAXDEPTH": "10000"},
 	}
 
-	result, issues := mapper.mapResponseList("queue", objects, false)
+	result, issues := mapper.mapResponseList("queue", objects)
 	if len(issues) > 0 {
 		t.Logf("mapping issues: %v", issues)
 	}
@@ -515,7 +515,7 @@ func TestMapValue_ListWithNonStringItems(t *testing.T) {
 			mappedKey = snakeName
 		}
 		if resultList, isList := result[mappedKey].([]any); isList {
-			if resultList[0] != 42 || resultList[1] != true {
+			if resultList[0] != 42 || !resultList[1].(bool) {
 				t.Errorf("non-string items should pass through, got %v", resultList)
 			}
 		}
@@ -756,7 +756,7 @@ func TestMapResponseList_StrictWithIssues(t *testing.T) {
 		{"UNKNOWN_ATTR_XYZ": "val"},
 	}
 
-	_, issues := mapper.mapResponseList("queue", objects, true)
+	_, issues := mapper.mapResponseList("queue", objects)
 	if len(issues) == 0 {
 		t.Error("expected issues for unknown attribute in strict mode")
 	}
@@ -822,7 +822,7 @@ func TestMapResponseList_ObjectIndexInIssues(t *testing.T) {
 		{valueMapKey: "UNKNOWN_TEST_VALUE_XYZ"},
 	}
 
-	_, issues := mapper.mapResponseList("queue", objects, true)
+	_, issues := mapper.mapResponseList("queue", objects)
 	foundWithIndex := false
 	for _, issue := range issues {
 		if issue.ObjectIndex != nil && *issue.ObjectIndex == 0 {
@@ -854,7 +854,7 @@ func TestMapResponseList_ObjectIndexInListIssues(t *testing.T) {
 		{valueMapKey: []any{"UNKNOWN_LIST_VAL_XYZ"}},
 	}
 
-	_, issues := mapper.mapResponseList("queue", objects, true)
+	_, issues := mapper.mapResponseList("queue", objects)
 	foundWithIndex := false
 	for _, issue := range issues {
 		if issue.ObjectIndex != nil {

--- a/mqrestadmin/session.go
+++ b/mqrestadmin/session.go
@@ -347,7 +347,7 @@ func (session *Session) applyResponseMapping(mappingQualifier string, objects []
 		return objects, nil
 	}
 
-	mapped, issues := session.mapper.mapResponseList(mappingQualifier, objects, session.mappingStrict)
+	mapped, issues := session.mapper.mapResponseList(mappingQualifier, objects)
 	if session.mappingStrict && len(issues) > 0 {
 		return nil, &MappingError{Issues: issues}
 	}

--- a/mqrestadmin/session_commands.go
+++ b/mqrestadmin/session_commands.go
@@ -49,19 +49,21 @@ func WithWhere(clause string) CommandOption {
 // DisplayQueue displays queue attributes. Name defaults to "*" if empty.
 func (session *Session) DisplayQueue(ctx context.Context, name string, opts ...CommandOption) ([]map[string]any, error) {
 	config := buildCommandConfig(opts)
-	if name == "" {
-		name = "*"
+	displayName := name
+	if displayName == "" {
+		displayName = "*"
 	}
-	return session.mqscCommand(ctx, "DISPLAY", "QUEUE", &name, config.requestParameters, config.responseParameters, config.where, true)
+	return session.mqscCommand(ctx, "DISPLAY", "QUEUE", &displayName, config.requestParameters, config.responseParameters, config.where, true)
 }
 
 // DisplayChannel displays channel attributes. Name defaults to "*" if empty.
 func (session *Session) DisplayChannel(ctx context.Context, name string, opts ...CommandOption) ([]map[string]any, error) {
 	config := buildCommandConfig(opts)
-	if name == "" {
-		name = "*"
+	displayName := name
+	if displayName == "" {
+		displayName = "*"
 	}
-	return session.mqscCommand(ctx, "DISPLAY", "CHANNEL", &name, config.requestParameters, config.responseParameters, config.where, true)
+	return session.mqscCommand(ctx, "DISPLAY", "CHANNEL", &displayName, config.requestParameters, config.responseParameters, config.where, true)
 }
 
 // ---------------------------------------------------------------------------

--- a/mqrestadmin/session_ensure.go
+++ b/mqrestadmin/session_ensure.go
@@ -125,11 +125,10 @@ func (session *Session) ensureObject(ctx context.Context, name string,
 	if err != nil {
 		// Command errors mean the object doesn't exist
 		var cmdErr *CommandError
-		if errors.As(err, &cmdErr) {
-			currentObjects = nil
-		} else {
+		if !errors.As(err, &cmdErr) {
 			return EnsureResult{}, fmt.Errorf("ensure %s display: %w", strings.ToLower(defineQualifier), err)
 		}
+		currentObjects = nil
 	}
 
 	// Step 2: Not found -> DEFINE


### PR DESCRIPTION
# Pull Request

## Summary

- Expand revive linter from 4 to 40 rules for Ruby/Java parity

## Issue Linkage

- Fixes #192

## Testing

- markdownlint
- `go vet ./...`
- `go test -race -count=1 ./...`

## Notes

- -