### PR TITLE
fix: LTPA cookie extraction uses prefix matching for suffixed cookie names

### DIFF
--- a/mqrestadmin/auth.go
+++ b/mqrestadmin/auth.go
@@ -42,7 +42,7 @@ type LTPAAuth struct {
 
 func (auth LTPAAuth) applyAuth(request *http.Request, session *Session) {
 	if session.ltpaToken != "" {
-		request.Header.Set("Cookie", "LtpaToken2="+session.ltpaToken)
+		request.Header.Set("Cookie", session.ltpaCookieName+"="+session.ltpaToken)
 	}
 }
 

--- a/mqrestadmin/integration_test.go
+++ b/mqrestadmin/integration_test.go
@@ -977,7 +977,7 @@ func TestSessionStatePopulatedAfterCommand(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// LTPA auth test (expected to fail on dev containers)
+// LTPA auth test
 // ---------------------------------------------------------------------------
 
 func TestLTPAAuthDisplayQmgr(t *testing.T) {
@@ -990,14 +990,12 @@ func TestLTPAAuthDisplayQmgr(t *testing.T) {
 		mqrestadmin.WithVerifyTLS(cfg.verifyTLS),
 	)
 	if err != nil {
-		t.Skipf("LTPA session creation failed (expected on dev containers): %v", err)
-		return
+		t.Fatalf("LTPA session creation failed: %v", err)
 	}
 
 	result, err := session.DisplayQmgr(context.Background())
 	if err != nil {
-		t.Skipf("LTPA DisplayQmgr failed (expected on dev containers): %v", err)
-		return
+		t.Fatalf("LTPA DisplayQmgr failed: %v", err)
 	}
 
 	if result == nil {

--- a/mqrestadmin/session.go
+++ b/mqrestadmin/session.go
@@ -467,7 +467,7 @@ func (session *Session) performLTPALogin(auth LTPAAuth) error {
 	return nil
 }
 
-func extractLTPAToken(headers map[string]string) (string, string) {
+func extractLTPAToken(headers map[string]string) (cookieName string, cookieValue string) {
 	for key, value := range headers {
 		// coverage-ignore -- Go 1.26 intermittently counts this branch differently
 		if !strings.EqualFold(key, "Set-Cookie") {

--- a/mqrestadmin/session.go
+++ b/mqrestadmin/session.go
@@ -34,8 +34,9 @@ type Session struct {
 	mappingStrict bool
 	csrfToken     *string
 	mapper        *attributeMapper
-	ltpaToken     string
-	clock         clock
+	ltpaCookieName string
+	ltpaToken      string
+	clock          clock
 
 	// LastHTTPStatus is the HTTP status code from the most recent command.
 	LastHTTPStatus int
@@ -456,16 +457,17 @@ func (session *Session) performLTPALogin(auth LTPAAuth) error {
 		return &AuthError{URL: loginURL, StatusCode: response.StatusCode}
 	}
 
-	token := extractLTPAToken(response.Headers)
+	cookieName, token := extractLTPAToken(response.Headers)
 	if token == "" {
 		return &AuthError{URL: loginURL, StatusCode: response.StatusCode}
 	}
 
+	session.ltpaCookieName = cookieName
 	session.ltpaToken = token
 	return nil
 }
 
-func extractLTPAToken(headers map[string]string) string {
+func extractLTPAToken(headers map[string]string) (string, string) {
 	for key, value := range headers {
 		// coverage-ignore -- Go 1.26 intermittently counts this branch differently
 		if !strings.EqualFold(key, "Set-Cookie") {
@@ -473,12 +475,15 @@ func extractLTPAToken(headers map[string]string) string {
 		}
 		for _, part := range strings.Split(value, ";") {
 			trimmed := strings.TrimSpace(part)
-			if strings.HasPrefix(trimmed, ltpaCookieName+"=") {
-				return strings.TrimPrefix(trimmed, ltpaCookieName+"=")
+			if strings.HasPrefix(trimmed, ltpaCookieName) {
+				eqIndex := strings.Index(trimmed, "=")
+				if eqIndex > 0 {
+					return trimmed[:eqIndex], trimmed[eqIndex+1:]
+				}
 			}
 		}
 	}
-	return ""
+	return "", ""
 }
 
 func parseResponsePayload(body string) (map[string]any, error) {

--- a/mqrestadmin/session.go
+++ b/mqrestadmin/session.go
@@ -467,7 +467,7 @@ func (session *Session) performLTPALogin(auth LTPAAuth) error {
 	return nil
 }
 
-func extractLTPAToken(headers map[string]string) (cookieName string, cookieValue string) {
+func extractLTPAToken(headers map[string]string) (cookieName, cookieValue string) {
 	for key, value := range headers {
 		// coverage-ignore -- Go 1.26 intermittently counts this branch differently
 		if !strings.EqualFold(key, "Set-Cookie") {

--- a/mqrestadmin/session_test.go
+++ b/mqrestadmin/session_test.go
@@ -74,6 +74,9 @@ func TestNewSession_LTPAAuth(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if session.ltpaCookieName != "LtpaToken2" {
+		t.Errorf("ltpaCookieName = %q, want %q", session.ltpaCookieName, "LtpaToken2")
+	}
 	if session.ltpaToken != "abc123token" {
 		t.Errorf("ltpaToken = %q, want %q", session.ltpaToken, "abc123token")
 	}
@@ -1113,9 +1116,12 @@ func TestExtractLTPAToken_MultipleHeaders(t *testing.T) {
 		"Content-Type": "application/json",
 		"Set-Cookie":   "LtpaToken2=abc123; Path=/; Secure",
 	}
-	result := extractLTPAToken(headers)
-	if result != "abc123" {
-		t.Errorf("extractLTPAToken() = %q, want abc123", result)
+	name, val := extractLTPAToken(headers)
+	if name != "LtpaToken2" {
+		t.Errorf("extractLTPAToken() name = %q, want LtpaToken2", name)
+	}
+	if val != "abc123" {
+		t.Errorf("extractLTPAToken() value = %q, want abc123", val)
 	}
 }
 


### PR DESCRIPTION
# Pull Request

## Summary

- Use prefix matching for LTPA cookie extraction to support Liberty suffixed cookie names

## Issue Linkage

- Fixes #223

## Testing

- markdownlint
- `go vet ./...`
- `go test -race -count=1 ./...`

## Notes

- -