### PR TITLE
docs: add cross-repo documentation links to docs site

### DIFF
--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -33,3 +33,5 @@ tables, and return shapes are under active development.
 ## License
 
 GNU General Public License v3.0
+
+--8<-- "other-languages.md"


### PR DESCRIPTION
# Pull Request

## Summary

- Add cross-repo documentation links to docs site home page

## Issue Linkage

- Fixes #225

## Testing

- markdownlint
- `go vet ./...`
- `go test -race -count=1 ./...`

## Notes

- -