### PR TITLE
feat(sync): add SyncConfig construction validation

### DIFF
--- a/mqrestadmin/session_sync.go
+++ b/mqrestadmin/session_sync.go
@@ -245,10 +245,10 @@ func hasStatus(rows []map[string]any, statusKeys []string, targetValues map[stri
 
 func normalizeSyncConfig(config SyncConfig) (SyncConfig, error) {
 	if config.Timeout < 0 {
-		return SyncConfig{}, fmt.Errorf("Timeout must not be negative, got %v", config.Timeout)
+		return SyncConfig{}, fmt.Errorf("timeout must not be negative, got %v", config.Timeout)
 	}
 	if config.PollInterval < 0 {
-		return SyncConfig{}, fmt.Errorf("PollInterval must not be negative, got %v", config.PollInterval)
+		return SyncConfig{}, fmt.Errorf("poll interval must not be negative, got %v", config.PollInterval)
 	}
 	if config.Timeout == 0 {
 		config.Timeout = defaultSyncTimeout

--- a/mqrestadmin/sync_test.go
+++ b/mqrestadmin/sync_test.go
@@ -186,7 +186,7 @@ func TestSyncConfig_NegativeTimeout(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for negative Timeout")
 	}
-	if !strings.Contains(err.Error(), "Timeout must not be negative") {
+	if !strings.Contains(err.Error(), "timeout must not be negative") {
 		t.Errorf("unexpected error message: %v", err)
 	}
 }
@@ -196,7 +196,7 @@ func TestSyncConfig_NegativePollInterval(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for negative PollInterval")
 	}
-	if !strings.Contains(err.Error(), "PollInterval must not be negative") {
+	if !strings.Contains(err.Error(), "poll interval must not be negative") {
 		t.Errorf("unexpected error message: %v", err)
 	}
 }

--- a/mqrestadmin/sync_test.go
+++ b/mqrestadmin/sync_test.go
@@ -213,6 +213,18 @@ func TestStartChannelSync_NegativeConfigError(t *testing.T) {
 	}
 }
 
+func TestStopChannelSync_NegativeConfigError(t *testing.T) {
+	transport := newMockTransport()
+	clock := newMockClock()
+	session := newTestSessionWithClock(transport, clock)
+
+	_, err := session.StopChannelSync(context.Background(), "TO.REMOTE",
+		SyncConfig{Timeout: -1 * time.Second})
+	if err == nil {
+		t.Fatal("expected error for negative Timeout")
+	}
+}
+
 func TestHasStatus(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
# Pull Request

## Summary

- Reject negative Timeout and PollInterval in SyncConfig at normalization time

## Issue Linkage

- Fixes #231

## Testing

- markdownlint
- `go vet ./...`
- `go test -race -count=1 ./...`

## Notes

- -