### PR TITLE
ci: add concurrency group to ci-push workflow

### DIFF
--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -8,6 +8,10 @@ on:
       - "hotfix/**"
       - "chore/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   security-events: write


### PR DESCRIPTION
## Summary

- Add a `concurrency` group to the `ci-push.yml` workflow so that new pushes to the same branch automatically cancel in-flight CI runs, reducing wasted runner minutes.

## Test plan

- [ ] Verify the workflow file is valid YAML
- [ ] Push two commits in quick succession to a feature branch and confirm the first run is cancelled

Ref: wphillipmoore/standard-tooling#148
