### PR TITLE
docs: document local MQ environment scripts for AI agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,54 @@ go tool cover -html=coverage.out                # View coverage in browser
   `COMPOSE_PROJECT_NAME=mqrest-go` and Go-specific port allocation
   (REST: 9463/9464, MQ: 1434/1435).
 
+### Local MQ Container
+
+The MQ development environment is owned by the
+[mq-rest-admin-dev-environment](https://github.com/wphillipmoore/mq-rest-admin-dev-environment)
+repository. Clone it as a sibling directory before running lifecycle
+scripts:
+
+```bash
+# Prerequisite (one-time)
+git clone https://github.com/wphillipmoore/mq-rest-admin-dev-environment.git ../mq-rest-admin-dev-environment
+
+# Start the containerized MQ queue managers
+./scripts/dev/mq_start.sh
+
+# Seed deterministic test objects (DEV.* prefix)
+./scripts/dev/mq_seed.sh
+
+# Verify REST-based MQSC responses
+./scripts/dev/mq_verify.sh
+
+# Stop the queue managers
+./scripts/dev/mq_stop.sh
+
+# Reset to clean state (removes data volumes)
+./scripts/dev/mq_reset.sh
+```
+
+The lifecycle scripts are thin wrappers that delegate to
+`../mq-rest-admin-dev-environment`. Override the path with `MQ_DEV_ENV_PATH`.
+
+Integration tests are gated by the `MQ_REST_ADMIN_RUN_INTEGRATION`
+environment variable. When unset, integration tests are skipped. For local
+runs:
+
+```bash
+./scripts/dev/mq_start.sh
+./scripts/dev/mq_seed.sh
+export MQ_REST_ADMIN_RUN_INTEGRATION=true
+go test -race -count=1 -tags=integration ./...
+```
+
+Container details:
+- Queue managers: `QM1` and `QM2`
+- QM1 ports: `1434` (MQ listener), `9463` (REST API)
+- QM2 ports: `1435` (MQ listener), `9464` (REST API)
+- Admin credentials: `mqadmin` / `mqadmin`
+- Object prefix: `DEV.*`
+
 ## Architecture
 
 Direct port of `pymqrest`'s architecture, adapted to Go idioms. Uses the


### PR DESCRIPTION
# Pull Request

## Summary

- Document local MQ environment scripts and integration test gate for AI agents

## Issue Linkage

- Ref #124

## Testing

- markdownlint
- `go vet ./...`
- `go test -race -count=1 ./...`

## Notes

- -