### PR TITLE
Container-first validation: remove fallbacks, add coverage, migrate CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,28 +51,22 @@ jobs:
       security-events: write
 
   # ---------------------------------------------------------------------------
-  # Dependency audit
+  # Dependency audit (containerised)
   # ---------------------------------------------------------------------------
   dependency-audit:
     name: "ci: dependency-audit"
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/wphillipmoore/dev-go:1.26
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: "1.26"
-
-      - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - name: Mark workspace safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Run govulncheck (fail on any vulnerability)
         run: govulncheck ./...
-
-      - name: Install go-licenses
-        run: go install github.com/google/go-licenses@latest
 
       - name: Run license compliance check
         run: >-
@@ -109,7 +103,7 @@ jobs:
         run: echo "Tag-based release validation not yet implemented for Go modules."
 
   # ---------------------------------------------------------------------------
-  # Unit tests — matrix over Go versions
+  # Unit tests — matrix over Go versions (containerised)
   # ---------------------------------------------------------------------------
   test-and-validate:
     name: "test: unit (${{ matrix.go-version }})"
@@ -118,18 +112,15 @@ jobs:
       fail-fast: false
       matrix:
         go-version: ${{ fromJSON(inputs.go-versions || '["1.25", "1.26"]') }}
+    container:
+      image: ghcr.io/wphillipmoore/dev-go:${{ matrix.go-version }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: ${{ matrix.go-version }}
-
-      - name: Install gocyclo
-        run: go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
+      - name: Mark workspace safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Run gocyclo (max complexity 15)
         run: gocyclo -over 15 ./mqrestadmin/
@@ -138,19 +129,17 @@ jobs:
         run: go vet ./...
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        run: golangci-lint run ./...
 
       - name: Run tests with coverage
         run: go test -race -count=1 -coverprofile=coverage.out ./...
-
-      - name: Install go-test-coverage
-        run: go install github.com/vladopajic/go-test-coverage/v2@latest
 
       - name: Enforce 100% coverage (excluding annotated lines)
         run: go-test-coverage --config .testcoverage.yml
 
   # ---------------------------------------------------------------------------
   # Integration tests — matrix over Go versions with unique MQ ports
+  # (kept on host — needs Docker-in-Docker for MQ containers)
   # ---------------------------------------------------------------------------
   integration-tests:
     name: "test: integration (${{ matrix.go-version }})"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,9 @@ jobs:
       - name: Run tests with coverage
         run: go test -race -count=1 -coverprofile=coverage.out ./...
 
+      - name: Install go-test-coverage (until baked into dev-go image)
+        run: go install github.com/vladopajic/go-test-coverage/v2@v2.18.3
+
       - name: Enforce 100% coverage (excluding annotated lines)
         run: go-test-coverage --config .testcoverage.yml
 

--- a/scripts/dev/audit.sh
+++ b/scripts/dev/audit.sh
@@ -4,19 +4,9 @@ set -euo pipefail
 export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-go:1.26}"
 export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-govulncheck ./... && go-licenses check ./... --allowed_licenses=Apache-2.0,BSD-2-Clause,BSD-3-Clause,MIT,ISC,MPL-2.0,GPL-3.0}"
 
-if command -v docker-test >/dev/null 2>&1; then
-  exec docker-test
+if ! command -v docker-test >/dev/null 2>&1; then
+  echo "ERROR: docker-test not found on PATH." >&2
+  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+  exit 1
 fi
-
-# Fallback: run docker directly if docker-test is not on PATH.
-repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
-
-echo "Image:   ${DOCKER_DEV_IMAGE}"
-echo "Command: ${DOCKER_TEST_CMD}"
-echo "---"
-
-exec docker run --rm \
-  -v "${repo_root}:/workspace" \
-  -w /workspace \
-  "${DOCKER_DEV_IMAGE}" \
-  bash -c "${DOCKER_TEST_CMD}"
+exec docker-test

--- a/scripts/dev/lint.sh
+++ b/scripts/dev/lint.sh
@@ -4,19 +4,9 @@ set -euo pipefail
 export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-go:1.26}"
 export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-golangci-lint run ./... && gocyclo -over 15 ./mqrestadmin/}"
 
-if command -v docker-test >/dev/null 2>&1; then
-  exec docker-test
+if ! command -v docker-test >/dev/null 2>&1; then
+  echo "ERROR: docker-test not found on PATH." >&2
+  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+  exit 1
 fi
-
-# Fallback: run docker directly if docker-test is not on PATH.
-repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
-
-echo "Image:   ${DOCKER_DEV_IMAGE}"
-echo "Command: ${DOCKER_TEST_CMD}"
-echo "---"
-
-exec docker run --rm \
-  -v "${repo_root}:/workspace" \
-  -w /workspace \
-  "${DOCKER_DEV_IMAGE}" \
-  bash -c "${DOCKER_TEST_CMD}"
+exec docker-test

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -2,21 +2,11 @@
 set -euo pipefail
 
 export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-go:1.26}"
-export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-go vet ./... && go test -race -count=1 -coverprofile=coverage.out ./...}"
+export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-go vet ./... && go test -race -count=1 -coverprofile=coverage.out ./... && go-test-coverage --config .testcoverage.yml}"
 
-if command -v docker-test >/dev/null 2>&1; then
-  exec docker-test
+if ! command -v docker-test >/dev/null 2>&1; then
+  echo "ERROR: docker-test not found on PATH." >&2
+  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+  exit 1
 fi
-
-# Fallback: run docker directly if docker-test is not on PATH.
-repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
-
-echo "Image:   ${DOCKER_DEV_IMAGE}"
-echo "Command: ${DOCKER_TEST_CMD}"
-echo "---"
-
-exec docker run --rm \
-  -v "${repo_root}:/workspace" \
-  -w /workspace \
-  "${DOCKER_DEV_IMAGE}" \
-  bash -c "${DOCKER_TEST_CMD}"
+exec docker-test

--- a/scripts/dev/typecheck.sh
+++ b/scripts/dev/typecheck.sh
@@ -4,19 +4,9 @@ set -euo pipefail
 export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-go:1.26}"
 export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-go vet ./...}"
 
-if command -v docker-test >/dev/null 2>&1; then
-  exec docker-test
+if ! command -v docker-test >/dev/null 2>&1; then
+  echo "ERROR: docker-test not found on PATH." >&2
+  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+  exit 1
 fi
-
-# Fallback: run docker directly if docker-test is not on PATH.
-repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
-
-echo "Image:   ${DOCKER_DEV_IMAGE}"
-echo "Command: ${DOCKER_TEST_CMD}"
-echo "---"
-
-exec docker run --rm \
-  -v "${repo_root}:/workspace" \
-  -w /workspace \
-  "${DOCKER_DEV_IMAGE}" \
-  bash -c "${DOCKER_TEST_CMD}"
+exec docker-test


### PR DESCRIPTION
## Summary
- Remove fallback `docker run` blocks from dev scripts
- Add `go-test-coverage --config .testcoverage.yml` to `test.sh`
- Migrate `test-and-validate` and `dependency-audit` CI jobs to `dev-go` container images
- Keep integration tests on host (needs Docker-in-Docker for MQ containers)

## Test plan
- [ ] Run `scripts/dev/test.sh` — tests + coverage pass in container
- [ ] Push a PR and verify CI runs in containers
- [ ] Verify integration tests still work on host

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)