### PR TITLE
ci: use dev-docs container for docs CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,7 @@ jobs:
   deploy:
     name: "deploy: docs"
     runs-on: ubuntu-latest
+    container: ghcr.io/wphillipmoore/dev-docs:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
# Pull Request

## Summary

- Run docs workflow inside ghcr.io/wphillipmoore/dev-docs:latest

## Issue Linkage

- Fixes #250

## Testing

- markdownlint
- ci: docs workflow passes with container

## Notes

- Merge after standard-tooling-docker#27 and standard-actions#174
- No other changes needed: already used @develop and had no manual install steps
