### PR TITLE
ci: use dev-docs container for docs CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,7 @@ jobs:
   deploy:
     name: "deploy: docs"
     runs-on: ubuntu-latest
+    container: ghcr.io/wphillipmoore/dev-docs:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
# Pull Request

## Summary

- Switch docs workflow to run inside ghcr.io/wphillipmoore/dev-docs:latest container.

## Issue Linkage

- Fixes #250

## Testing

- markdownlint
- `go vet ./...`
- `go test -race -count=1 ./...`

## Notes

- -