### PR TITLE
feat: adopt git worktree convention for parallel AI agent development

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,14 +65,6 @@ jobs:
       - name: Mark workspace safe for git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      # Override the container's Go toolchain with 1.26.2 to pick up stdlib
-      # fixes for GO-2026-4870, GO-2026-4946, GO-2026-4947. Revert once
-      # dev-go:1.26 image is rebuilt (tracked as a separate follow-up).
-      - name: Set up Go 1.26.2 (stdlib CVE fixes)
-        uses: actions/setup-go@v6
-        with:
-          go-version: "1.26.2"
-
       - name: Run govulncheck (fail on any vulnerability)
         run: govulncheck ./...
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,14 @@ jobs:
       - name: Mark workspace safe for git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
+      # Override the container's Go toolchain with 1.26.2 to pick up stdlib
+      # fixes for GO-2026-4870, GO-2026-4946, GO-2026-4947. Revert once
+      # dev-go:1.26 image is rebuilt (tracked as a separate follow-up).
+      - name: Set up Go 1.26.2 (stdlib CVE fixes)
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26.2"
+
       - name: Run govulncheck (fail on any vulnerability)
         run: govulncheck ./...
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,12 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Run govulncheck (fail on any vulnerability)
+        env:
+          # Force auto-download of go1.26.2 for this step only, so the
+          # stdlib scan sees the CVE fixes for GO-2026-4870, GO-2026-4946,
+          # GO-2026-4947. The container ships go1.26.1. Revert this env
+          # override once dev-go:1.26 has been rebuilt upstream.
+          GOTOOLCHAIN: go1.26.2
         run: govulncheck ./...
 
       - name: Run license compliance check

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ __pycache__/
 # Editor/IDE
 # .idea/
 # .vscode/
+.worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,72 @@ belong in managed, version-controlled documentation (CLAUDE.md, AGENTS.md,
 skills, or docs/). If you want to persist something, tell the human what you
 would save and let them decide where it belongs.
 
+## Parallel AI agent development
+
+This repository supports running multiple Claude Code agents in parallel via
+git worktrees. The convention keeps parallel agents' working trees isolated
+while preserving shared project memory (which Claude Code derives from the
+session's starting CWD).
+
+**Canonical spec:**
+[`standard-tooling/docs/specs/worktree-convention.md`](https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/specs/worktree-convention.md)
+— full rationale, trust model, failure modes, and memory-path implications.
+The canonical text lives in `standard-tooling`; this section is the local
+on-ramp.
+
+### Structure
+
+```text
+~/dev/github/mq-rest-admin-go/            ← sessions ALWAYS start here
+  .git/
+  CLAUDE.md, cmd/, internal/, …           ← main worktree (usually `develop`)
+  .worktrees/                             ← container for parallel worktrees
+    issue-258-adopt-worktree-convention/  ← worktree on feature/258-...
+    …
+```
+
+### Rules
+
+1. **Sessions always start at the project root.**
+   `cd ~/dev/github/mq-rest-admin-go && claude` — never from inside
+   `.worktrees/<name>/`. This keeps the memory-path slug stable and shared.
+2. **Each parallel agent is assigned exactly one worktree.** The session
+   prompt names the worktree (see Agent prompt contract below).
+   - For Read / Edit / Write tools: use the worktree's absolute path.
+   - For Bash commands that touch files: `cd` into the worktree first,
+     or use absolute paths.
+3. **The main worktree is read-only.** All edits flow through a worktree
+   on a feature branch — the logical endpoint of the standing
+   "no direct commits to `develop`" policy.
+4. **One worktree per issue.** Don't stack in-flight issues. When a
+   branch lands, remove the worktree before starting the next.
+5. **Naming: `issue-<N>-<short-slug>`.** `<N>` is the GitHub issue
+   number; `<short-slug>` is 2–4 kebab-case tokens.
+
+### Agent prompt contract
+
+When launching a parallel-agent session, use this template (fill in the
+placeholders):
+
+```text
+You are working on issue #<N>: <issue title>.
+
+Your worktree is: /Users/pmoore/dev/github/mq-rest-admin-go/.worktrees/issue-<N>-<slug>/
+Your branch is:   feature/<N>-<slug>
+
+Rules for this session:
+- Do all git operations from inside your worktree:
+    cd <absolute-worktree-path> && git <command>
+- For Read / Edit / Write tools, use the absolute worktree path.
+- For Bash commands that touch files, cd into the worktree first
+  or use absolute paths.
+- Do not edit files at the project root. The main worktree is
+  read-only — all changes flow through your worktree on your
+  feature branch.
+```
+
+All fields are required.
+
 ## Project Overview
 
 This is a Go port of `pymqrest`, providing a Go wrapper for the IBM MQ administrative REST API. The project provides typed Go functions for every MQSC command exposed by the `runCommandJSON` REST endpoint, with automatic attribute name translation between Go `snake_case` and native MQSC parameter names.

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/wphillipmoore/mq-rest-admin-go
 
 go 1.25.0
 
-toolchain go1.26.2
-
 require (
 	github.com/fzipp/gocyclo v0.6.0
 	github.com/vladopajic/go-test-coverage/v2 v2.18.3

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/wphillipmoore/mq-rest-admin-go
 
 go 1.25.0
 
+toolchain go1.26.2
+
 require (
 	github.com/fzipp/gocyclo v0.6.0
 	github.com/vladopajic/go-test-coverage/v2 v2.18.3


### PR DESCRIPTION
# Pull Request

## Summary

- Apply the parallel AI agent worktree convention from wphillipmoore/standard-tooling#258 to mq-rest-admin-go — .gitignore entry for .worktrees/ and a Parallel AI agent development section in CLAUDE.md with the five rules and the canonical Agent prompt contract.

## Issue Linkage

- Fixes #258

## Testing

- markdownlint
- `go vet ./...`
- `go test -race -count=1 ./...`

## Notes

- Fleet-cascade step for wphillipmoore/standard-tooling#258 (parallel AI agent worktree convention). Same two-file change every active consuming repo in the standard-* suite gets:

.gitignore: add .worktrees/ (local convention, never committed).

CLAUDE.md: new "Parallel AI agent development" section — structure diagram, five rules, canonical Agent prompt contract, link to the canonical spec in standard-tooling.

Canonical spec, plan, pushback and alignment review artifacts all live in standard-tooling — this PR is the local on-ramp. No behavior change beyond new agent-facing documentation + the gitignore entry.

Auto-merge note: allow_auto_merge was disabled on all managed repos on 2026-04-22, so st-submit-pr's auto-merge enablement will fail noisily during submission. The PR itself is created correctly and waits for manual merge, which is the new default workflow.