### PR TITLE
chore(ci): migrate standard-actions refs from @develop to @v1.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
   # Security and standards (shared reusable workflow)
   # ---------------------------------------------------------------------------
   security-and-standards:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@develop
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.3
     with:
       language: go
       semgrep-language: golang
@@ -99,7 +99,7 @@ jobs:
 
       - name: Version divergence gate (PRs targeting develop)
         if: github.event_name == 'pull_request' && github.base_ref == 'develop'
-        uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@develop
+        uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@v1.3
         with:
           head-version-command: grep -oP 'Version\s*=\s*"\K[^"]+' mqrestadmin/version.go
           main-version-command: git show origin/main:mqrestadmin/version.go | grep -oP 'Version\s*=\s*"\K[^"]+'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Deploy docs
-        uses: wphillipmoore/standard-actions/actions/docs-deploy@develop
+        uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.3
         with:
           version-command: grep -oP 'Version\s*=\s*"\K[^"]+' mqrestadmin/version.go | cut -d. -f1,2
           checkout-common: "true"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   publish:
-    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@develop
+    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.3
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
# Pull Request

## Summary

- Migrate standard-actions refs from @develop to @v1.3

## Issue Linkage

- Closes #262

## Testing

- markdownlint
- `go vet ./...`
- `go test -race -count=1 ./...`

## Notes

- Pins all standard-actions refs to @v1.3 rolling minor tag. Tracking: standard-actions#145.