### PR TITLE
Align CI job names with CI gates and add [ci] config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     uses: wphillipmoore/standard-actions/.github/workflows/ci-quality.yml@v1.5
     with:
       language: go
-      versions: '["1.26"]'
+      versions: ${{ inputs.go-versions || '["1.25", "1.26"]' }}
 
   test:
     uses: wphillipmoore/standard-actions/.github/workflows/ci-test.yml@v1.5
@@ -49,10 +49,14 @@ jobs:
       versions: ${{ inputs.go-versions || '["1.25", "1.26"]' }}
 
   audit:
-    name: "audit / dependencies"
+    name: "audit / dependencies / ${{ matrix.go-version }}"
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: ${{ fromJSON(inputs.go-versions || '["1.25", "1.26"]') }}
     container:
-      image: ghcr.io/wphillipmoore/dev-go:1.26
+      image: ghcr.io/wphillipmoore/dev-go:${{ matrix.go-version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -61,8 +65,6 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Run govulncheck
-        env:
-          GOTOOLCHAIN: go1.26.2
         run: govulncheck ./...
 
       - name: Run license compliance check
@@ -108,7 +110,6 @@ jobs:
     uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.5
     with:
       language: go
-      semgrep-language: golang
       run-standards: ${{ inputs.run-release || 'true' }}
       run-security: ${{ inputs.run-security || 'true' }}
     permissions:

--- a/standard-tooling.toml
+++ b/standard-tooling.toml
@@ -9,6 +9,10 @@ primary-language = "go"
 claude = "Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>"
 codex = "Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>"
 
+[ci]
+versions = ["1.25", "1.26"]
+integration-tests = true
+
 [markdownlint]
 ignore = ["docs/site/docs"]
 


### PR DESCRIPTION
# Pull Request

## Summary

- Align CI job names with CI gates and add [ci] config

## Issue Linkage

- Ref #281

## Testing

- `st-docker-run -- st-validate`
- `go vet ./...`
- `go test -race -count=1 ./...`

## Notes

- Ref #281

## Summary

- Expand quality workflow versions from latest-only (`["1.26"]`) to
  full test matrix (`["1.25", "1.26"]`) so `quality / lint` and
  `quality / typecheck` checks exist for all Go versions
- Add version matrix to bespoke audit job so check names match the
  `audit / dependencies / {version}` pattern expected by CI gates
- Remove stale `semgrep-language: golang` input (removed in
  ci-security.yml v1.5, causes startup_failure)
- Remove `GOTOOLCHAIN` workaround — container images should ship
  current patch releases
- Add `[ci]` section to `standard-tooling.toml` with versions and
  integration-tests config so `st-github-config apply` generates the
  CI gates ruleset with required status checks

## Test plan

- [ ] All CI jobs run and produce correctly named status checks
- [ ] `quality / lint / 1.25` and `quality / lint / 1.26` both exist
- [ ] `audit / dependencies / 1.25` and `audit / dependencies / 1.26` both exist
- [ ] `st-github-config apply` creates CI gates ruleset after merge