### PR TITLE
ci: replace bespoke audit job with ci-audit reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,28 +49,10 @@ jobs:
       versions: ${{ inputs.go-versions || '["1.25", "1.26"]' }}
 
   audit:
-    name: "audit / dependencies / ${{ matrix.go-version }}"
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        go-version: ${{ fromJSON(inputs.go-versions || '["1.25", "1.26"]') }}
-    container:
-      image: ghcr.io/wphillipmoore/dev-go:${{ matrix.go-version }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Mark workspace safe for git
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-      - name: Run govulncheck
-        run: govulncheck ./...
-
-      - name: Run license compliance check
-        run: >-
-          go-licenses check ./...
-          --allowed_licenses=Apache-2.0,BSD-2-Clause,BSD-3-Clause,MIT,ISC,MPL-2.0,GPL-3.0
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-audit.yml@v1.5
+    with:
+      language: go
+      versions: ${{ inputs.go-versions || '["1.25", "1.26"]' }}
 
   integration-tests:
     name: "test / integration / ${{ matrix.go-version }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,8 +92,8 @@ jobs:
     uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.5
     with:
       language: go
-      run-standards: ${{ inputs.run-release || 'true' }}
-      run-security: ${{ inputs.run-security || 'true' }}
+      run-standards: ${{ inputs.run-release != 'false' }}
+      run-security: ${{ inputs.run-security != 'false' }}
     permissions:
       contents: read
       security-events: write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,9 +127,8 @@ st-docker-run -- st-validate   # Canonical validation (runs in dev container)
 
 PR CI (`.github/workflows/ci.yml`) uses standard-actions v1.5 reusable
 workflows for quality (lint, typecheck), unit tests (Go 1.25/1.26
-matrix), security (CodeQL, Trivy, Semgrep, standards), and release gates.
-Bespoke jobs handle dependency audit (go-licenses with allowlist and
-GOTOOLCHAIN override) and integration tests (MQ containers).
+matrix), dependency audit, security (CodeQL, Trivy, Semgrep, standards),
+and release gates. A bespoke job handles integration tests (MQ containers).
 
 ### Testing
 


### PR DESCRIPTION
# Pull Request

## Summary

- Replace bespoke audit job with ci-audit reusable workflow

## Issue Linkage

- Ref #283

## Testing

- `st-docker-run -- st-validate`
- `go vet ./...`
- `go test -race -count=1 ./...`

## Notes

- Replace the bespoke audit job (govulncheck + go-licenses steps) with the
centralized ci-audit.yml reusable workflow from standard-actions v1.5.
The go-licenses allowlist and GOTOOLCHAIN override that originally
required a bespoke job have been integrated into the centralized
workflow. Update CLAUDE.md to reflect that audit is no longer bespoke.

CI check names are preserved: the reusable workflow names its job
"dependencies / <version>", so calling it from the "audit" job key
produces "CI / audit / dependencies / 1.25" — matching the existing
gate configuration.