### PR TITLE
fix(ci): specify language, container-tag, and registry-publish in publish-release caller

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -13,4 +13,8 @@ permissions:
 jobs:
   publish:
     uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.5
+    with:
+      language: go
+      container-tag: "1.26"
+      registry-publish: true
     secrets: inherit


### PR DESCRIPTION
# Pull Request

## Summary

- Specify language: go, container-tag: 1.26, and registry-publish: true for crates.io publishing

## Issue Linkage

- Ref wphillipmoore/standard-actions#412

## Testing

- `st-docker-run -- st-validate`
- `go vet ./...`
- `go test -race -count=1 ./...`

## Notes

- -