### PR TITLE
chore!: migrate to mq-rest-admin-project org and vergil tooling

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,13 +1,13 @@
 {
   "extraKnownMarketplaces": {
-    "standard-tooling-marketplace": {
+    "vergil-marketplace": {
       "source": {
         "source": "github",
-        "repo": "wphillipmoore/standard-tooling-plugin"
+        "repo": "vergil-project/vergil-plugin"
       }
     }
   },
   "enabledPlugins": {
-    "standard-tooling@standard-tooling-marketplace": true
+    "vergil@vergil-marketplace": true
   }
 }

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-# Canonical source: wphillipmoore/standard-tooling/.github/ISSUE_TEMPLATE/config.yml
+# Canonical source: vergil-project/vergil-tooling/.github/ISSUE_TEMPLATE/config.yml
 # Do not modify repo-local copies — update the canonical source and re-sync.
 #
 blank_issues_enabled: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,2 +1,2 @@
 > **Do not create PRs manually.**
-> Use [`st-submit-pr`](https://wphillipmoore.github.io/standard-tooling/reference/dev/submit-pr/).
+> Use [`vrg-submit-pr`](https://vergil-project.github.io/vergil-tooling/reference/dev/submit-pr/).

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,4 +1,4 @@
-# https://github.com/wphillipmoore/standard-actions/blob/develop/.github/workflows/README.md
+# https://github.com/vergil-project/vergil-actions/blob/develop/.github/workflows/README.md
 name: CD
 
 on:
@@ -14,20 +14,22 @@ permissions:
 
 jobs:
   docs:
-    uses: wphillipmoore/standard-actions/.github/workflows/cd-docs.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/cd-docs.yml@v2.0
     with:
       pre-deploy-command: >-
         git clone --depth 1 --branch develop
-        https://github.com/wphillipmoore/mq-rest-admin-common.git
+        https://github.com/mq-rest-admin-project/mq-rest-admin-common.git
         .mq-rest-admin-common
     permissions:
       contents: write
 
   release:
     if: github.ref == 'refs/heads/main'
-    uses: wphillipmoore/standard-actions/.github/workflows/cd-release.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/cd-release.yml@v2.0
     with:
       language: go
       container-tag: "1.26"
       registry-publish: true
-    secrets: inherit
+    secrets:
+      APP_CLIENT_ID: ${{ secrets.APP_CLIENT_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# https://github.com/wphillipmoore/standard-actions/blob/develop/.github/workflows/README.md
+# https://github.com/vergil-project/vergil-actions/blob/develop/.github/workflows/README.md
 name: CI
 
 on:
@@ -37,7 +37,7 @@ concurrency:
 
 jobs:
   audit:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-audit.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/ci-audit.yml@v2.0
     with:
       language: go
       versions: ${{ inputs.go-versions || '["1.25", "1.26"]' }}
@@ -59,7 +59,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
 
       - name: Setup MQ environment
-        uses: wphillipmoore/mq-rest-admin-dev-environment/.github/actions/setup-mq@main
+        uses: mq-rest-admin-project/mq-rest-admin-dev-environment/.github/actions/setup-mq@main
         with:
           project-name: mqrest-go-${{ matrix.project-suffix }}
           qm1-rest-port: ${{ matrix.qm1-rest-port }}
@@ -77,13 +77,13 @@ jobs:
           go test -race -count=1 -tags=integration ./...
 
   quality:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-quality.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v2.0
     with:
       language: go
       versions: ${{ inputs.go-versions || '["1.25", "1.26"]' }}
 
   security:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.0
     with:
       language: go
       run-standards: ${{ inputs.run-release != 'false' }}
@@ -93,13 +93,13 @@ jobs:
       security-events: write
 
   test:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-test.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/ci-test.yml@v2.0
     with:
       language: go
       versions: ${{ inputs.go-versions || '["1.25", "1.26"]' }}
 
   version:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-version-bump.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/ci-version-bump.yml@v2.0
     with:
       language: go
       run-release: ${{ inputs.run-release != 'false' }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
 # Agent Instructions
 
-**Standards reference**: <https://github.com/wphillipmoore/standards-and-conventions>
-— active standards documentation lives in the standard-tooling repository under `docs/`.
-Repository profile: `standard-tooling.toml`.
+**Standards reference**: <https://github.com/vergil-project/vergil-tooling>
+— active standards documentation lives in the vergil-tooling repository under `docs/`.
+Repository profile: `vergil.toml`.
 
 ## User Overrides (Optional)
 
@@ -13,15 +13,15 @@ briefly and continue.
 ## Canonical Standards
 
 This repository follows the canonical standards and conventions in the
-`standards-and-conventions` repository.
+`vergil-tooling` repository.
 
 Resolve the local path (preferred):
 
-- `../standards-and-conventions`
+- `../vergil-tooling`
 
 If the local path is unavailable, use the canonical web source:
 
-- <https://github.com/wphillipmoore/standards-and-conventions>
+- <https://github.com/vergil-project/vergil-tooling>
 
 If the canonical standards cannot be retrieved, treat it as a fatal
 exception and stop.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,9 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-**Standards reference**: <https://github.com/wphillipmoore/standards-and-conventions>
-— active standards documentation lives in the standard-tooling repository under `docs/`.
-Repository profile: `standard-tooling.toml`.
+**Standards reference**: <https://github.com/vergil-project/vergil-tooling>
+— active standards documentation lives in the vergil-tooling repository under `docs/`.
+Repository profile: `vergil.toml`.
 
 ## Memory management
 
@@ -15,9 +15,9 @@ plugin/skill issue) before writing. See that file for the full
 workflow.
 
 Available skills:
-- `/standard-tooling:memory-init` — set up or update the policy header
+- `/vergil:memory-init` — set up or update the policy header
   in a project's `MEMORY.md`.
-- `/standard-tooling:memory-audit` — structured collaborative review
+- `/vergil:memory-audit` — structured collaborative review
   of memory files.
 
 ## Parallel AI agent development
@@ -28,9 +28,9 @@ while preserving shared project memory (which Claude Code derives from the
 session's starting CWD).
 
 **Canonical spec:**
-[`standard-tooling/docs/specs/worktree-convention.md`](https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/specs/worktree-convention.md)
+[`vergil-tooling/docs/specs/worktree-convention.md`](https://github.com/vergil-project/vergil-tooling/blob/develop/docs/specs/worktree-convention.md)
 — full rationale, trust model, failure modes, and memory-path implications.
-The canonical text lives in `standard-tooling`; this section is the local
+The canonical text lives in `vergil-tooling`; this section is the local
 on-ramp.
 
 ### Structure
@@ -94,11 +94,11 @@ This is a Go port of `pymqrest`, providing a Go wrapper for the IBM MQ administr
 
 **Status**: Pre-alpha (initial setup)
 
-**Module path**: `github.com/wphillipmoore/mq-rest-admin-go`
+**Module path**: `github.com/mq-rest-admin-project/mq-rest-admin-go`
 
 **Package name**: `mqrestadmin`
 
-**Canonical Standards**: This repository follows standards at <https://github.com/wphillipmoore/standards-and-conventions> (local path: `../standards-and-conventions` if available)
+**Canonical Standards**: This repository follows standards at <https://github.com/vergil-project/vergil-tooling> (local path: `../vergil-tooling` if available)
 
 ## Development Commands
 
@@ -107,8 +107,8 @@ This is a Go port of `pymqrest`, providing a Go wrapper for the IBM MQ administr
 - **Go**: 1.25+ (CI tests 1.25 and 1.26; go.mod declares 1.26)
 - **golangci-lint**: `brew install golangci-lint` (not in `tools.go` per project recommendation)
 - **Dev tools** (pinned in `tools.go`): `go install golang.org/x/vuln/cmd/govulncheck && go install github.com/vladopajic/go-test-coverage/v2 && go install github.com/fzipp/gocyclo/cmd/gocyclo`
-- **Git hooks**: `git config core.hooksPath ../standard-tooling/scripts/lib/git-hooks` (required before committing)
-- **Standard tooling**: CLI tools (`st-commit`, `st-validate`, etc.) are pre-installed in the dev container images
+- **Git hooks**: `git config core.hooksPath ../vergil-tooling/scripts/lib/git-hooks` (required before committing)
+- **VERGIL CLI tools (`vrg-commit`, `vrg-validate`, etc.) are pre-installed in the dev container images
 
 ### Build
 
@@ -120,7 +120,7 @@ go vet ./...            # Static analysis
 ### Validation
 
 ```bash
-st-docker-run -- st-validate   # Canonical validation (runs in dev container)
+vrg-docker-run -- vrg-validate   # Canonical validation (runs in dev container)
 ```
 
 ### CI
@@ -148,7 +148,7 @@ go tool cover -html=coverage.out                # View coverage in browser
   annotated with `// coverage-ignore -- <reason>` on the **preceding line** (the
   `{` line) and excluded from measurement.
 - **Integration tests**: Require `MQ_REST_ADMIN_RUN_INTEGRATION=1` and a running
-  MQ container. CI uses the `wphillipmoore/mq-rest-admin-dev-environment` action.
+  MQ container. CI uses the `mq-rest-admin-project/mq-rest-admin-dev-environment` action.
   Wrapper scripts in `scripts/dev/mq_*.sh` manage the MQ lifecycle with
   `COMPOSE_PROJECT_NAME=mqrest-go` and Go-specific port allocation
   (REST: 9463/9464, MQ: 1434/1435).
@@ -156,13 +156,13 @@ go tool cover -html=coverage.out                # View coverage in browser
 ### Local MQ Container
 
 The MQ development environment is owned by the
-[mq-rest-admin-dev-environment](https://github.com/wphillipmoore/mq-rest-admin-dev-environment)
+[mq-rest-admin-dev-environment](https://github.com/mq-rest-admin-project/mq-rest-admin-dev-environment)
 repository. Clone it as a sibling directory before running lifecycle
 scripts:
 
 ```bash
 # Prerequisite (one-time)
-git clone https://github.com/wphillipmoore/mq-rest-admin-dev-environment.git ../mq-rest-admin-dev-environment
+git clone https://github.com/mq-rest-admin-project/mq-rest-admin-dev-environment.git ../mq-rest-admin-dev-environment
 
 # Start the containerized MQ queue managers
 ./scripts/dev/mq_start.sh

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ parameter names, so you work with idiomatic Go identifiers throughout.
 ## Installation
 
 ```bash
-go get github.com/wphillipmoore/mq-rest-admin-go/mqrestadmin
+go get github.com/mq-rest-admin-project/mq-rest-admin-go/mqrestadmin
 ```
 
 Requires Go 1.25+. Zero external runtime dependencies.
@@ -34,7 +34,7 @@ import (
     "fmt"
     "time"
 
-    "github.com/wphillipmoore/mq-rest-admin-go/mqrestadmin"
+    "github.com/mq-rest-admin-project/mq-rest-admin-go/mqrestadmin"
 )
 
 func main() {

--- a/docs/plans/go-port-plan.md
+++ b/docs/plans/go-port-plan.md
@@ -52,7 +52,7 @@ providing typed Go functions for every MQSC command exposed by the
 ### Naming
 
 - **Repository**: `mq-rest-admin-go`
-- **Module path**: `github.com/wphillipmoore/mq-rest-admin-go`
+- **Module path**: `github.com/mq-rest-admin-project/mq-rest-admin-go`
 - **Package name**: `mqrest` (short, lowercase, single word per Go conventions)
 
 Follows the family naming pattern established by `mq-rest-admin` (Java), with
@@ -64,7 +64,7 @@ a `-go` suffix to distinguish the language.
 mq-rest-admin-go/
 ├── docs/
 │   ├── decisions/
-│   └── standards-and-conventions.md
+│   └── vergil-tooling.md
 ├── mqrestadmin/                    # Main package
 │   ├── session.go             # Session type, builder/options, core dispatch
 │   ├── session_commands.go    # MQSC command methods (display, define, alter, delete, etc.)
@@ -310,7 +310,7 @@ const (
 ### Phase 1: Foundation
 
 1. **Project scaffolding** -- `go.mod`, directory structure, CLAUDE.md,
-   AGENTS.md, `docs/standards-and-conventions.md`
+   AGENTS.md, `docs/vergil-tooling.md`
 2. **Error types** (`errors.go`) -- all 6 error structs with `Error()` methods
 3. **Transport interface and default implementation** (`transport.go`) --
    `Transport` interface, `HTTPTransport` struct using `net/http`

--- a/docs/plans/implementation-progress.md
+++ b/docs/plans/implementation-progress.md
@@ -145,4 +145,4 @@ See `docs/plans/go-port-plan.md` for full rationale. Summary:
 
 - **Python original**: `../pymqrest`
 - **Java port**: `../mq-rest-admin`
-- **Go standards**: `../standards-and-conventions/docs/development/go/`
+- **Go standards**: `../vergil-tooling/docs/development/go/`

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -21,7 +21,7 @@
 Canonical local validation command:
 
 ```bash
-st-docker-run -- st-validate
+vrg-docker-run -- vrg-validate
 ```
 
 ## Tooling requirement
@@ -32,7 +32,7 @@ Required for daily workflow:
 - `golangci-lint` (`brew install golangci-lint`)
 - `gocyclo` (`go install github.com/fzipp/gocyclo/cmd/gocyclo@latest`)
 - `govulncheck` (`go install golang.org/x/vuln/cmd/govulncheck@latest`)
-- `st-docker-run -- st-validate` (canonical validation)
+- `vrg-docker-run -- vrg-validate` (canonical validation)
 
 ## Merge strategy override
 
@@ -51,7 +51,7 @@ submission. Do not construct commit messages or PR bodies manually.
 ### Committing
 
 ```bash
-st-commit \
+vrg-commit \
   --type TYPE --message MESSAGE --agent AGENT \
   [--scope SCOPE] [--body BODY]
 ```
@@ -64,12 +64,12 @@ st-commit \
 - `--body` (optional): detailed commit body
 
 The script resolves the correct `Co-Authored-By` identity from
-`standard-tooling.toml` and the git hooks validate the result.
+`vergil.toml` and the git hooks validate the result.
 
 ### Submitting PRs
 
 ```bash
-st-submit-pr \
+vrg-submit-pr \
   --issue NUMBER --summary TEXT \
   [--linkage KEYWORD] [--title TEXT] \
   [--notes TEXT] [--docs-only] [--dry-run]

--- a/docs/site/docs/api/auth.md
+++ b/docs/site/docs/api/auth.md
@@ -11,7 +11,7 @@ Pass a credential value to `NewSession` as the third argument. Always use TLS
 transit.
 
 ```go
-import "github.com/wphillipmoore/mq-rest-admin-go/mqrestadmin"
+import "github.com/mq-rest-admin-project/mq-rest-admin-go/mqrestadmin"
 
 // mTLS client certificate auth -- strongest; no shared secrets
 session, err := mqrestadmin.NewSession(

--- a/docs/site/docs/api/session.md
+++ b/docs/site/docs/api/session.md
@@ -16,7 +16,7 @@ standard Go library conventions.
 Use `NewSession` with functional options:
 
 ```go
-import "github.com/wphillipmoore/mq-rest-admin-go/mqrestadmin"
+import "github.com/mq-rest-admin-project/mq-rest-admin-go/mqrestadmin"
 
 session, err := mqrestadmin.NewSession(
     "https://localhost:9443/ibmmq/rest/v2",

--- a/docs/site/docs/design/rationale.md
+++ b/docs/site/docs/design/rationale.md
@@ -24,7 +24,7 @@ sub-packages to import. This follows the Go convention of small, focused
 packages and keeps the import path simple:
 
 ```go
-import "github.com/wphillipmoore/mq-rest-admin-go/mqrestadmin"
+import "github.com/mq-rest-admin-project/mq-rest-admin-go/mqrestadmin"
 ```
 
 ### Functional options

--- a/docs/site/docs/development/contributing.md
+++ b/docs/site/docs/development/contributing.md
@@ -68,7 +68,7 @@ go build ./... && go vet ./... && go test -race ./...
 - **Claude Code**: reads `CLAUDE.md`, which loads repository standards
   via include directives.
 - **Codex and other agents**: reads `AGENTS.md`, which loads the same
-  standards plus shared skills from the `standards-and-conventions`
+  standards plus shared skills from the `vergil-tooling`
   repository.
 
 ### Quality expectations

--- a/docs/site/docs/development/developer-setup.md
+++ b/docs/site/docs/development/developer-setup.md
@@ -17,9 +17,9 @@ mqrestadmin depends on two sibling repositories:
 
 | Repository | Purpose |
 | --- | --- |
-| [mq-rest-admin-go](https://github.com/wphillipmoore/mq-rest-admin-go) | This project |
-| [standards-and-conventions](https://github.com/wphillipmoore/standards-and-conventions) | Canonical project standards (referenced by `AGENTS.md` and git hooks) |
-| [mq-rest-admin-dev-environment](https://github.com/wphillipmoore/mq-rest-admin-dev-environment) | Dockerized MQ test infrastructure (local and CI) |
+| [mq-rest-admin-go](https://github.com/mq-rest-admin-project/mq-rest-admin-go) | This project |
+| [vergil-tooling](https://github.com/vergil-project/vergil-tooling) | Canonical project standards (referenced by `AGENTS.md` and git hooks) |
+| [mq-rest-admin-dev-environment](https://github.com/mq-rest-admin-project/mq-rest-admin-dev-environment) | Dockerized MQ test infrastructure (local and CI) |
 
 ## Recommended directory layout
 
@@ -28,15 +28,15 @@ Clone all three repositories as siblings:
 ```text
 ~/dev/
 ├── mq-rest-admin-go/
-├── standards-and-conventions/
+├── vergil-tooling/
 └── mq-rest-admin-dev-environment/
 ```
 
 ```bash
 cd ~/dev
-git clone https://github.com/wphillipmoore/mq-rest-admin-go.git
-git clone https://github.com/wphillipmoore/standards-and-conventions.git
-git clone https://github.com/wphillipmoore/mq-rest-admin-dev-environment.git
+git clone https://github.com/mq-rest-admin-project/mq-rest-admin-go.git
+git clone https://github.com/vergil-project/vergil-tooling.git
+git clone https://github.com/mq-rest-admin-project/mq-rest-admin-dev-environment.git
 ```
 
 ## Building

--- a/docs/site/docs/development/quality-gates.md
+++ b/docs/site/docs/development/quality-gates.md
@@ -1,8 +1,8 @@
 # Quality gates
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/wphillipmoore/mq-rest-admin-go)](https://goreportcard.com/report/github.com/wphillipmoore/mq-rest-admin-go)
+[![Go Report Card](https://goreportcard.com/badge/github.com/mq-rest-admin-project/mq-rest-admin-go)](https://goreportcard.com/report/github.com/mq-rest-admin-project/mq-rest-admin-go)
 
-[Go Report Card](https://goreportcard.com/report/github.com/wphillipmoore/mq-rest-admin-go)
+[Go Report Card](https://goreportcard.com/report/github.com/mq-rest-admin-project/mq-rest-admin-go)
 runs six automated checks against the codebase: go vet, gofmt, gocyclo,
 ineffassign, license, and misspell. All of these overlap with checks
 already enforced by the local validation pipeline and CI.

--- a/docs/site/docs/examples.md
+++ b/docs/site/docs/examples.md
@@ -2,9 +2,9 @@
 
 Runnable example programs demonstrate common MQ administration tasks using
 `mqrestadmin`. Each example has a core function in the
-[`examples/`](https://github.com/wphillipmoore/mq-rest-admin-go/tree/main/examples)
+[`examples/`](https://github.com/mq-rest-admin-project/mq-rest-admin-go/tree/main/examples)
 package and a standalone `main.go` entry point in
-[`examples/cmd/`](https://github.com/wphillipmoore/mq-rest-admin-go/tree/main/examples/cmd).
+[`examples/cmd/`](https://github.com/mq-rest-admin-project/mq-rest-admin-go/tree/main/examples/cmd).
 
 ## Prerequisites
 
@@ -39,7 +39,7 @@ summary for each queue manager.
 go run ./examples/cmd/healthcheck
 ```
 
-See [`examples/healthcheck.go`](https://github.com/wphillipmoore/mq-rest-admin-go/blob/main/examples/healthcheck.go).
+See [`examples/healthcheck.go`](https://github.com/mq-rest-admin-project/mq-rest-admin-go/blob/main/examples/healthcheck.go).
 
 ## Queue depth monitor
 
@@ -50,7 +50,7 @@ approaching capacity, and sorts by depth percentage.
 go run ./examples/cmd/depthmonitor
 ```
 
-See [`examples/depthmonitor.go`](https://github.com/wphillipmoore/mq-rest-admin-go/blob/main/examples/depthmonitor.go).
+See [`examples/depthmonitor.go`](https://github.com/mq-rest-admin-project/mq-rest-admin-go/blob/main/examples/depthmonitor.go).
 
 ## Channel status report
 
@@ -61,7 +61,7 @@ channels that are defined but not running, and shows connection details.
 go run ./examples/cmd/channelstatus
 ```
 
-See [`examples/channelstatus.go`](https://github.com/wphillipmoore/mq-rest-admin-go/blob/main/examples/channelstatus.go).
+See [`examples/channelstatus.go`](https://github.com/mq-rest-admin-project/mq-rest-admin-go/blob/main/examples/channelstatus.go).
 
 ## Environment provisioner
 
@@ -72,7 +72,7 @@ across two queue managers, then verifies connectivity. Includes teardown.
 go run ./examples/cmd/provisionenv
 ```
 
-See [`examples/provisionenv.go`](https://github.com/wphillipmoore/mq-rest-admin-go/blob/main/examples/provisionenv.go).
+See [`examples/provisionenv.go`](https://github.com/mq-rest-admin-project/mq-rest-admin-go/blob/main/examples/provisionenv.go).
 
 ## Dead letter queue inspector
 
@@ -83,7 +83,7 @@ and suggests actions when messages are present.
 go run ./examples/cmd/dlqinspector
 ```
 
-See [`examples/dlqinspector.go`](https://github.com/wphillipmoore/mq-rest-admin-go/blob/main/examples/dlqinspector.go).
+See [`examples/dlqinspector.go`](https://github.com/mq-rest-admin-project/mq-rest-admin-go/blob/main/examples/dlqinspector.go).
 
 ## Queue status and connection handles
 
@@ -95,4 +95,4 @@ structures into uniform flat maps.
 go run ./examples/cmd/queuestatus
 ```
 
-See [`examples/queuestatus.go`](https://github.com/wphillipmoore/mq-rest-admin-go/blob/main/examples/queuestatus.go).
+See [`examples/queuestatus.go`](https://github.com/mq-rest-admin-project/mq-rest-admin-go/blob/main/examples/queuestatus.go).

--- a/docs/site/docs/getting-started.md
+++ b/docs/site/docs/getting-started.md
@@ -8,7 +8,7 @@
 ## Installation
 
 ```bash
-go get github.com/wphillipmoore/mq-rest-admin-go/mqrestadmin
+go get github.com/mq-rest-admin-project/mq-rest-admin-go/mqrestadmin
 ```
 
 ## Creating a session
@@ -23,7 +23,7 @@ import (
     "context"
     "time"
 
-    "github.com/wphillipmoore/mq-rest-admin-go/mqrestadmin"
+    "github.com/mq-rest-admin-project/mq-rest-admin-go/mqrestadmin"
 )
 
 func main() {

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -1,6 +1,6 @@
 # mqrestadmin
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/wphillipmoore/mq-rest-admin-go)](https://goreportcard.com/report/github.com/wphillipmoore/mq-rest-admin-go)
+[![Go Report Card](https://goreportcard.com/badge/github.com/mq-rest-admin-project/mq-rest-admin-go)](https://goreportcard.com/report/github.com/mq-rest-admin-project/mq-rest-admin-go)
 
 ## Overview
 
@@ -22,7 +22,7 @@ and error propagation.
 ## Installation
 
 ```bash
-go get github.com/wphillipmoore/mq-rest-admin-go/mqrestadmin
+go get github.com/mq-rest-admin-project/mq-rest-admin-go/mqrestadmin
 ```
 
 ## Status

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: mqrestadmin (Go)
-site_url: https://wphillipmoore.github.io/mq-rest-admin-go/
+site_url: https://mq-rest-admin-project.github.io/mq-rest-admin-go/
 site_description: Go wrapper for the IBM MQ administrative REST API
-repo_url: https://github.com/wphillipmoore/mq-rest-admin-go
+repo_url: https://github.com/mq-rest-admin-project/mq-rest-admin-go
 repo_name: mq-rest-admin-go
 edit_uri: ""
 

--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -1,7 +1,7 @@
 # Standards and Conventions
 
 This repository follows the canonical standards at:
-<https://github.com/wphillipmoore/standards-and-conventions>
+<https://github.com/vergil-project/vergil-tooling>
 
 ## Table of Contents
 
@@ -9,7 +9,7 @@ This repository follows the canonical standards at:
 - [Project-specific overlay](#project-specific-overlay)
 
 ## Canonical references
-<!-- include: ../standards-and-conventions/docs/standards-and-conventions.md -->
+<!-- include: ../vergil-tooling/docs/vergil-tooling.md -->
 
 ## Project-specific overlay
 

--- a/examples/channelstatus.go
+++ b/examples/channelstatus.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/wphillipmoore/mq-rest-admin-go/mqrestadmin"
+	"github.com/mq-rest-admin-project/mq-rest-admin-go/mqrestadmin"
 )
 
 // ChannelInfo holds combined channel definition and status information.

--- a/examples/cmd/channelstatus/main.go
+++ b/examples/cmd/channelstatus/main.go
@@ -13,8 +13,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/wphillipmoore/mq-rest-admin-go/examples"
-	"github.com/wphillipmoore/mq-rest-admin-go/mqrestadmin"
+	"github.com/mq-rest-admin-project/mq-rest-admin-go/examples"
+	"github.com/mq-rest-admin-project/mq-rest-admin-go/mqrestadmin"
 )
 
 func main() {

--- a/examples/cmd/depthmonitor/main.go
+++ b/examples/cmd/depthmonitor/main.go
@@ -14,8 +14,8 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/wphillipmoore/mq-rest-admin-go/examples"
-	"github.com/wphillipmoore/mq-rest-admin-go/mqrestadmin"
+	"github.com/mq-rest-admin-project/mq-rest-admin-go/examples"
+	"github.com/mq-rest-admin-project/mq-rest-admin-go/mqrestadmin"
 )
 
 func main() {

--- a/examples/cmd/dlqinspector/main.go
+++ b/examples/cmd/dlqinspector/main.go
@@ -13,8 +13,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/wphillipmoore/mq-rest-admin-go/examples"
-	"github.com/wphillipmoore/mq-rest-admin-go/mqrestadmin"
+	"github.com/mq-rest-admin-project/mq-rest-admin-go/examples"
+	"github.com/mq-rest-admin-project/mq-rest-admin-go/mqrestadmin"
 )
 
 func main() {

--- a/examples/cmd/healthcheck/main.go
+++ b/examples/cmd/healthcheck/main.go
@@ -13,8 +13,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/wphillipmoore/mq-rest-admin-go/examples"
-	"github.com/wphillipmoore/mq-rest-admin-go/mqrestadmin"
+	"github.com/mq-rest-admin-project/mq-rest-admin-go/examples"
+	"github.com/mq-rest-admin-project/mq-rest-admin-go/mqrestadmin"
 )
 
 func main() {

--- a/examples/cmd/provisionenv/main.go
+++ b/examples/cmd/provisionenv/main.go
@@ -14,8 +14,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/wphillipmoore/mq-rest-admin-go/examples"
-	"github.com/wphillipmoore/mq-rest-admin-go/mqrestadmin"
+	"github.com/mq-rest-admin-project/mq-rest-admin-go/examples"
+	"github.com/mq-rest-admin-project/mq-rest-admin-go/mqrestadmin"
 )
 
 func main() {

--- a/examples/cmd/queuestatus/main.go
+++ b/examples/cmd/queuestatus/main.go
@@ -14,8 +14,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/wphillipmoore/mq-rest-admin-go/examples"
-	"github.com/wphillipmoore/mq-rest-admin-go/mqrestadmin"
+	"github.com/mq-rest-admin-project/mq-rest-admin-go/examples"
+	"github.com/mq-rest-admin-project/mq-rest-admin-go/mqrestadmin"
 )
 
 func main() {

--- a/examples/depthmonitor.go
+++ b/examples/depthmonitor.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/wphillipmoore/mq-rest-admin-go/mqrestadmin"
+	"github.com/mq-rest-admin-project/mq-rest-admin-go/mqrestadmin"
 )
 
 // QueueDepthInfo holds depth information for a single queue.

--- a/examples/dlqinspector.go
+++ b/examples/dlqinspector.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/wphillipmoore/mq-rest-admin-go/mqrestadmin"
+	"github.com/mq-rest-admin-project/mq-rest-admin-go/mqrestadmin"
 )
 
 const criticalDepthPct = 90.0

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/wphillipmoore/mq-rest-admin-go/mqrestadmin"
+	"github.com/mq-rest-admin-project/mq-rest-admin-go/mqrestadmin"
 )
 
 // ---------------------------------------------------------------------------

--- a/examples/healthcheck.go
+++ b/examples/healthcheck.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/wphillipmoore/mq-rest-admin-go/mqrestadmin"
+	"github.com/mq-rest-admin-project/mq-rest-admin-go/mqrestadmin"
 )
 
 // ListenerResult holds the health status for a single listener.

--- a/examples/integration_test.go
+++ b/examples/integration_test.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/wphillipmoore/mq-rest-admin-go/examples"
-	"github.com/wphillipmoore/mq-rest-admin-go/mqrestadmin"
+	"github.com/mq-rest-admin-project/mq-rest-admin-go/examples"
+	"github.com/mq-rest-admin-project/mq-rest-admin-go/mqrestadmin"
 )
 
 func TestMain(m *testing.M) {

--- a/examples/mock_test.go
+++ b/examples/mock_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wphillipmoore/mq-rest-admin-go/mqrestadmin"
+	"github.com/mq-rest-admin-project/mq-rest-admin-go/mqrestadmin"
 )
 
 // mockTransport is a test Transport that records calls and returns

--- a/examples/provisionenv.go
+++ b/examples/provisionenv.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/wphillipmoore/mq-rest-admin-go/mqrestadmin"
+	"github.com/mq-rest-admin-project/mq-rest-admin-go/mqrestadmin"
 )
 
 const prefix = "PROV"

--- a/examples/queuestatus.go
+++ b/examples/queuestatus.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/wphillipmoore/mq-rest-admin-go/mqrestadmin"
+	"github.com/mq-rest-admin-project/mq-rest-admin-go/mqrestadmin"
 )
 
 // QueueHandleInfo holds per-handle queue status information.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/wphillipmoore/mq-rest-admin-go
+module github.com/mq-rest-admin-project/mq-rest-admin-go
 
 go 1.25.0
 

--- a/mqrestadmin/integration_test.go
+++ b/mqrestadmin/integration_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wphillipmoore/mq-rest-admin-go/mqrestadmin"
+	"github.com/mq-rest-admin-project/mq-rest-admin-go/mqrestadmin"
 )
 
 // ---------------------------------------------------------------------------

--- a/vergil.toml
+++ b/vergil.toml
@@ -6,8 +6,7 @@ release-model = "artifact-publishing"
 primary-language = "go"
 
 [project.co-authors]
-claude = "Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>"
-codex = "Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>"
+agent = "Co-Authored-By: wphillipmoore-agent <284101533+wphillipmoore-agent@users.noreply.github.com>"
 
 [ci]
 versions = ["1.25", "1.26"]
@@ -21,4 +20,4 @@ release = true
 docs = true
 
 [dependencies]
-standard-tooling = "v1.4"
+vergil = "v2.0"


### PR DESCRIPTION
## Summary

Migrates mq-rest-admin-go from `wphillipmoore` personal account to `mq-rest-admin-project` organization and adopts vergil tooling.

**BREAKING CHANGE**: Go module path changes from `github.com/wphillipmoore/mq-rest-admin-go` to `github.com/mq-rest-admin-project/mq-rest-admin-go`.

- Rename `standard-tooling.toml` to `vergil.toml` with vergil v2.0 dependency
- Update CI/CD workflows to `vergil-project/vergil-actions@v2.0` with explicit secrets
- Update Go module path in `go.mod` and all source/test files
- Update all repo URLs, docs URLs to `mq-rest-admin-project` org
- Consolidate co-author entries to single `wphillipmoore-agent` identity

## Test plan

- [ ] CI workflows resolve `vergil-project/vergil-actions@v2.0` correctly
- [ ] All unit tests pass with new module path
- [ ] No remaining references to `wphillipmoore` in active files

Ref mq-rest-admin-project/mq-rest-admin-common#195

🤖 Generated with [Claude Code](https://claude.ai/claude-code)