### PR TITLE
feat(docs): add label to version selector in site header

### DIFF
--- a/docs/site/docs/stylesheets/extra.css
+++ b/docs/site/docs/stylesheets/extra.css
@@ -1,0 +1,7 @@
+.md-version::before {
+  content: "Version:";
+  margin-right: 0.4em;
+  font-size: 0.8rem;
+  color: var(--md-primary-bg-color);
+  opacity: 0.7;
+}

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -37,6 +37,9 @@ extra:
   version:
     provider: mike
 
+extra_css:
+  - stylesheets/extra.css
+
 plugins:
   - search
 


### PR DESCRIPTION
# Pull Request

## Summary

- Add CSS rule to display a visible Version: label next to the MkDocs Material version selector dropdown, making it easier for readers to identify the version picker.

## Issue Linkage

- Ref mq-rest-admin-project/mq-rest-admin-go#299

## Notes

- -