### PR TITLE
chore(tooling): migrate to vergil v2.1

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,7 +21,8 @@
     "vergil-marketplace": {
       "source": {
         "source": "github",
-        "repo": "vergil-project/vergil-claude-plugin"
+        "repo": "vergil-project/vergil-claude-plugin",
+        "ref": "v2.1"
       }
     }
   },

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   docs:
-    uses: vergil-project/vergil-actions/.github/workflows/cd-docs.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/cd-docs.yml@v2.1
     with:
       pre-deploy-command: >-
         git clone --depth 1 --branch develop
@@ -25,7 +25,7 @@ jobs:
 
   release:
     if: github.ref == 'refs/heads/main'
-    uses: vergil-project/vergil-actions/.github/workflows/cd-release.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/cd-release.yml@v2.1
     with:
       language: go
       container-tag: "1.26"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -92,6 +93,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      actions: read
 
   test:
     uses: vergil-project/vergil-actions/.github/workflows/ci-test.yml@v2.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ concurrency:
 
 jobs:
   audit:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-audit.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/ci-audit.yml@v2.1
     with:
       language: go
       versions: ${{ inputs.go-versions || '["1.25", "1.26"]' }}
@@ -78,13 +78,13 @@ jobs:
           go test -race -count=1 -tags=integration ./...
 
   quality:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v2.1
     with:
       language: go
       versions: ${{ inputs.go-versions || '["1.25", "1.26"]' }}
 
   security:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.1
     with:
       language: go
       run-standards: ${{ inputs.run-release != 'false' }}
@@ -94,14 +94,14 @@ jobs:
       security-events: write
 
   test:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-test.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/ci-test.yml@v2.1
     with:
       language: go
       versions: ${{ inputs.go-versions || '["1.25", "1.26"]' }}
       container-suffix: go
 
   version:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-version-bump.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/ci-version-bump.yml@v2.1
     with:
       language: go
       run-release: ${{ inputs.run-release != 'false' }}

--- a/vergil.toml
+++ b/vergil.toml
@@ -17,4 +17,4 @@ release = true
 docs = true
 
 [dependencies]
-vergil = "v2.0"
+vergil = "v2.1"


### PR DESCRIPTION
# Pull Request

## Summary

- Migrate mq-rest-admin-go tooling from vergil v2.0 to v2.1 and grant the actions: read permission the v2.1 ci-security caller now requires.

## Issue Linkage

- Ref #314

## Notes

- Scope: bumped vergil.toml dependency v2.0->v2.1, all 7 vergil-actions reusable-workflow refs (5 in ci.yml, 2 in cd.yml), and the .claude/settings.json marketplace ref (added ref: v2.1). actions:read rationale: v2.1 ci-security.yml requests actions: read from its caller (breaking caller-contract change per vergil-actions#698; v2.1 rolling tag resolves to v2.1.5 which carries the request), so actions: read was added to both the top-level permissions block and the security job permissions block in ci.yml; without it the PR fails at startup. Version-divergence: VERSION shows 1.2.2 while latest release tag is v1.2.1 (one patch ahead, unreleased pending bump) - noted only, VERSION not edited (chore commits don't trigger ci-version-bump). Validate: green. repo-config audit local verdict: compliant (remote gh api 403 expected in this credential scope).